### PR TITLE
feat(cfe-validate): validate borrowed sub-items safely

### DIFF
--- a/.claude/skills/cfe-validate/SKILL.md
+++ b/.claude/skills/cfe-validate/SKILL.md
@@ -26,7 +26,7 @@ allowed-tools:
 powershell.exe -NoProfile -File .claude/skills/cfe-validate/scripts/cfe-validate.ps1 -ExtensionPath src
 ```
 
-## Проверки (9 шагов)
+## Проверки (10 шагов)
 
 | # | Проверка | Уровень |
 |---|----------|---------|
@@ -39,6 +39,7 @@ powershell.exe -NoProfile -File .claude/skills/cfe-validate/scripts/cfe-validate
 | 7 | Файлы языков существуют | WARN |
 | 8 | Каталоги объектов существуют | WARN |
 | 9 | Заимствованные объекты: ObjectBelonging=Adopted, ExtendedConfigurationObject UUID | ERROR/WARN |
+| 10 | Заимствованные sub-items: Attribute, TabularSection, EnumValue с явными borrowed-метаданными | ERROR |
 
 ## Пример вывода
 

--- a/.claude/skills/cfe-validate/scripts/cfe-validate.ps1
+++ b/.claude/skills/cfe-validate/scripts/cfe-validate.ps1
@@ -527,11 +527,66 @@ if ($childObjNode) {
 
 if ($script:stopped) { & $finalize; exit 1 }
 
-# --- Check 9: Borrowed objects validation ---
+function Test-BorrowedMetadataDeclared {
+	param([System.Xml.XmlNode]$SubItem, [System.Xml.XmlNamespaceManager]$Ns)
+
+	$subProps = $SubItem.SelectSingleNode("md:Properties", $Ns)
+	if (-not $subProps) { return $false }
+
+	$subOb = $subProps.SelectSingleNode("md:ObjectBelonging", $Ns)
+	if ($subOb -and $subOb.InnerText) { return $true }
+
+	$subExt = $subProps.SelectSingleNode("md:ExtendedConfigurationObject", $Ns)
+	return [bool]($subExt -and $subExt.InnerText)
+}
+
+function Test-BorrowedSubItem {
+	param(
+		[string]$CheckNum,
+		[string]$Context,
+		[string]$SubType,
+		[System.Xml.XmlNode]$SubItem,
+		[System.Xml.XmlNamespaceManager]$Ns
+	)
+
+	$subProps = $SubItem.SelectSingleNode("md:Properties", $Ns)
+	if (-not $subProps) {
+		Report-Error "${CheckNum}. ${Context}: ${SubType} missing Properties"
+		return $false
+	}
+
+	$ok = $true
+	$subOb = $subProps.SelectSingleNode("md:ObjectBelonging", $Ns)
+	if (-not $subOb -or $subOb.InnerText -ne "Adopted") {
+		Report-Error "${CheckNum}. ${Context}: ${SubType} ObjectBelonging must be 'Adopted'"
+		$ok = $false
+	}
+
+	$subName = $subProps.SelectSingleNode("md:Name", $Ns)
+	$subNameVal = if ($subName -and $subName.InnerText) { $subName.InnerText } else { "?" }
+	if (-not $subName -or -not $subName.InnerText) {
+		Report-Error "${CheckNum}. ${Context}: ${SubType} missing Name"
+		$ok = $false
+	}
+
+	$subExt = $subProps.SelectSingleNode("md:ExtendedConfigurationObject", $Ns)
+	if (-not $subExt -or -not $subExt.InnerText) {
+		Report-Error "${CheckNum}. ${Context}: ${SubType}.${subNameVal} missing ExtendedConfigurationObject"
+		$ok = $false
+	} elseif ($subExt.InnerText -notmatch $guidPattern) {
+		Report-Error "${CheckNum}. ${Context}: ${SubType}.${subNameVal} invalid ExtendedConfigurationObject"
+		$ok = $false
+	}
+
+	return $ok
+}
+
 if ($childObjNode) {
 	$borrowedCount = 0
 	$borrowedOk = 0
 	$check9Ok = $true
+	$borrowedSubItemCount = 0
+	$check10Ok = $true
 
 	foreach ($child in $childObjNode.ChildNodes) {
 		if ($child.NodeType -ne 'Element') { continue }
@@ -572,7 +627,8 @@ if ($childObjNode) {
 		if (-not $objProps) { continue }
 
 		$obNode = $objProps.SelectSingleNode("md:ObjectBelonging", $objNs)
-		if ($obNode -and $obNode.InnerText -eq "Adopted") {
+		$isBorrowedObject = $obNode -and $obNode.InnerText -eq "Adopted"
+		if ($isBorrowedObject) {
 			$borrowedCount++
 
 			# Check ExtendedConfigurationObject
@@ -588,6 +644,47 @@ if ($childObjNode) {
 			}
 		}
 
+		$objChildObjects = $objEl.SelectSingleNode("md:ChildObjects", $objNs)
+		if ($objChildObjects) {
+			$ctx = "${typeName}.${childName}"
+			foreach ($subItem in $objChildObjects.ChildNodes) {
+				if ($subItem.NodeType -ne 'Element') { continue }
+				$subType = $subItem.LocalName
+
+				if ($subType -eq "Attribute" -or $subType -eq "TabularSection") {
+					if (-not $isBorrowedObject -or -not (Test-BorrowedMetadataDeclared $subItem $objNs)) { continue }
+					$borrowedSubItemCount++
+					if (-not (Test-BorrowedSubItem "10" $ctx $subType $subItem $objNs)) {
+						$check10Ok = $false
+					}
+
+					if ($subType -ne "TabularSection") { continue }
+
+					$tsProps = $subItem.SelectSingleNode("md:Properties", $objNs)
+					$tsName = if ($tsProps) { $tsProps.SelectSingleNode("md:Name", $objNs) } else { $null }
+					$tsLabel = if ($tsName -and $tsName.InnerText) { $tsName.InnerText } else { "?" }
+					$tsChildObjects = $subItem.SelectSingleNode("md:ChildObjects", $objNs)
+					if (-not $tsChildObjects) { continue }
+
+					foreach ($tsAttr in $tsChildObjects.ChildNodes) {
+						if ($tsAttr.NodeType -ne 'Element' -or $tsAttr.LocalName -ne "Attribute") { continue }
+						if (-not (Test-BorrowedMetadataDeclared $tsAttr $objNs)) { continue }
+						$borrowedSubItemCount++
+						if (-not (Test-BorrowedSubItem "10" "${ctx}.ТЧ.${tsLabel}" "Attribute" $tsAttr $objNs)) {
+							$check10Ok = $false
+						}
+					}
+				}
+				elseif ($subType -eq "EnumValue" -and $typeName -eq "Enum") {
+					if (-not $isBorrowedObject -or -not (Test-BorrowedMetadataDeclared $subItem $objNs)) { continue }
+					$borrowedSubItemCount++
+					if (-not (Test-BorrowedSubItem "10" $ctx "EnumValue" $subItem $objNs)) {
+						$check10Ok = $false
+					}
+				}
+			}
+		}
+
 		if ($script:stopped) { break }
 	}
 
@@ -595,6 +692,12 @@ if ($childObjNode) {
 		Report-OK "9. Borrowed objects: none found"
 	} elseif ($check9Ok) {
 		Report-OK "9. Borrowed objects: $borrowedOk/$borrowedCount validated"
+	}
+
+	if ($borrowedSubItemCount -eq 0) {
+		Report-OK "10. Borrowed sub-items: none found"
+	} elseif ($check10Ok) {
+		Report-OK "10. Borrowed sub-items: $borrowedSubItemCount validated"
 	}
 }
 

--- a/.claude/skills/cfe-validate/scripts/cfe-validate.py
+++ b/.claude/skills/cfe-validate/scripts/cfe-validate.py
@@ -518,11 +518,47 @@ def main():
         r.finalize(out_file)
         sys.exit(1)
 
+    def validate_borrowed_sub_item(check_num, context, sub_type, sub_item):
+        sub_props = sub_item.find(f'{{{NS["md"]}}}Properties')
+        if sub_props is None:
+            r.error(f'{check_num}. {context}: {sub_type} missing Properties')
+            return False
+        ok = True
+        sub_ob = sub_props.find(f'{{{NS["md"]}}}ObjectBelonging')
+        if sub_ob is None or (sub_ob.text or '') != 'Adopted':
+            r.error(f"{check_num}. {context}: {sub_type} ObjectBelonging must be 'Adopted'")
+            ok = False
+        sub_name = sub_props.find(f'{{{NS["md"]}}}Name')
+        if sub_name is None or not (sub_name.text or ''):
+            r.error(f'{check_num}. {context}: {sub_type} missing Name')
+            ok = False
+        sub_ext = sub_props.find(f'{{{NS["md"]}}}ExtendedConfigurationObject')
+        sub_name_val = (sub_name.text or '') if sub_name is not None else '?'
+        if sub_ext is None or not (sub_ext.text or ''):
+            r.error(f'{check_num}. {context}: {sub_type}.{sub_name_val} missing ExtendedConfigurationObject')
+            ok = False
+        elif not GUID_PATTERN.match(sub_ext.text):
+            r.error(f'{check_num}. {context}: {sub_type}.{sub_name_val} invalid ExtendedConfigurationObject')
+            ok = False
+        return ok
+
+    def borrowed_metadata_declared(sub_item):
+        sub_props = sub_item.find(f'{{{NS["md"]}}}Properties')
+        if sub_props is None:
+            return False
+        sub_ob = sub_props.find(f'{{{NS["md"]}}}ObjectBelonging')
+        if sub_ob is not None and (sub_ob.text or ''):
+            return True
+        sub_ext = sub_props.find(f'{{{NS["md"]}}}ExtendedConfigurationObject')
+        return sub_ext is not None and bool(sub_ext.text or '')
+
     # --- Check 9: Borrowed objects validation ---
     if child_obj_node is not None:
         borrowed_count = 0
         borrowed_ok_count = 0
         check9_ok = True
+        borrowed_sub_item_count = 0
+        check10_ok = True
 
         for child in child_obj_node:
             if not isinstance(child.tag, str):
@@ -565,7 +601,8 @@ def main():
                 continue
 
             ob_node = obj_props.find(f'{{{NS["md"]}}}ObjectBelonging')
-            if ob_node is not None and (ob_node.text or '') == 'Adopted':
+            is_borrowed_object = ob_node is not None and (ob_node.text or '') == 'Adopted'
+            if is_borrowed_object:
                 borrowed_count += 1
 
                 # Check ExtendedConfigurationObject
@@ -579,6 +616,46 @@ def main():
                 else:
                     borrowed_ok_count += 1
 
+            obj_child_objects = obj_el.find(f'{{{NS["md"]}}}ChildObjects')
+            if obj_child_objects is not None:
+                ctx = f'{type_name}.{child_name}'
+                for sub_item in obj_child_objects:
+                    if not isinstance(sub_item.tag, str):
+                        continue
+                    sub_type = etree.QName(sub_item.tag).localname
+
+                    if sub_type in ('Attribute', 'TabularSection'):
+                        if not is_borrowed_object or not borrowed_metadata_declared(sub_item):
+                            continue
+                        borrowed_sub_item_count += 1
+                        if not validate_borrowed_sub_item('10', ctx, sub_type, sub_item):
+                            check10_ok = False
+                        if sub_type != 'TabularSection':
+                            continue
+                        ts_props = sub_item.find(f'{{{NS["md"]}}}Properties')
+                        ts_name = ts_props.find(f'{{{NS["md"]}}}Name') if ts_props is not None else None
+                        ts_label = (ts_name.text or '?') if ts_name is not None else '?'
+                        ts_child_objects = sub_item.find(f'{{{NS["md"]}}}ChildObjects')
+                        if ts_child_objects is None:
+                            continue
+                        for ts_attr in ts_child_objects:
+                            if not isinstance(ts_attr.tag, str):
+                                continue
+                            if etree.QName(ts_attr.tag).localname != 'Attribute':
+                                continue
+                            if not borrowed_metadata_declared(ts_attr):
+                                continue
+                            borrowed_sub_item_count += 1
+                            if not validate_borrowed_sub_item('10', f'{ctx}.ТЧ.{ts_label}', 'Attribute', ts_attr):
+                                check10_ok = False
+
+                    elif sub_type == 'EnumValue' and type_name == 'Enum':
+                        if not is_borrowed_object or not borrowed_metadata_declared(sub_item):
+                            continue
+                        borrowed_sub_item_count += 1
+                        if not validate_borrowed_sub_item('10', ctx, 'EnumValue', sub_item):
+                            check10_ok = False
+
             if r.stopped:
                 break
 
@@ -586,6 +663,11 @@ def main():
             r.ok('9. Borrowed objects: none found')
         elif check9_ok:
             r.ok(f'9. Borrowed objects: {borrowed_ok_count}/{borrowed_count} validated')
+
+        if borrowed_sub_item_count == 0:
+            r.ok('10. Borrowed sub-items: none found')
+        elif check10_ok:
+            r.ok(f'10. Borrowed sub-items: {borrowed_sub_item_count} validated')
 
     # --- Final output ---
     r.finalize(out_file)


### PR DESCRIPTION
## Summary
- add borrowed sub-item validation for `Attribute`, `TabularSection`, and `EnumValue` in both Python and PowerShell `cfe-validate` scripts
- skip false positives for newly added extension sub-items by validating only elements that explicitly declare borrowed metadata
- update the skill docs to describe the new `Borrowed sub-items` check

## Validation
- ran `python3 .claude/skills/cfe-validate/scripts/cfe-validate.py -ExtensionPath /home/prog7/РабочееПространство/projects/1C_Projects/ERP/src/cfe/AkitorgMTUT`
- result: `0 errors, 0 warnings`