### PR TITLE
fix(form): Проверка уникальности элементов форм  при compile/edit/validate

### DIFF
--- a/.claude/skills/form-compile/scripts/form-compile.ps1
+++ b/.claude/skills/form-compile/scripts/form-compile.ps1
@@ -3174,6 +3174,39 @@ function Compute-MainAcbAutofill {
 	return $true
 }
 
+# --- 11c. Validate unique element names (1C requirement) ---
+$script:typeKeyList = @("columnGroup","group","input","check","radio","label","labelField","table","pages","page","button","picture","picField","calendar","cmdBar","popup")
+function Validate-UniqueNames {
+	param($elementsList, [hashtable]$seen = @{})
+	foreach ($el in $elementsList) {
+		if ($null -eq $el) { continue }
+		$typeKey = $null
+		foreach ($key in $script:typeKeyList) {
+			if ($null -ne $el.PSObject.Properties[$key] -and $null -ne $el.$key) { $typeKey = $key; break }
+		}
+		if ($typeKey) {
+			$elName = Get-ElementName -el $el -typeKey $typeKey
+			if ($seen.ContainsKey($elName)) {
+				Write-Error "Duplicate element name '$elName' — element names must be unique in 1C form"
+				exit 1
+			}
+			$seen[$elName] = $true
+		}
+		# Recurse into children
+		if ($el.PSObject.Properties["children"] -and $el.children) {
+			Validate-UniqueNames -elementsList $el.children -seen $seen
+		}
+		if ($el.PSObject.Properties["columns"] -and $el.columns) {
+			Validate-UniqueNames -elementsList $el.columns -seen $seen
+		}
+	}
+}
+$allNames = @{}
+if ($def.elements) { Validate-UniqueNames -elementsList $def.elements -seen $allNames }
+if ($script:mainAcbDef -and $script:mainAcbDef.children) {
+	Validate-UniqueNames -elementsList $script:mainAcbDef.children -seen $allNames
+}
+
 # --- 12. Main compilation ---
 
 # Title

--- a/.claude/skills/form-compile/scripts/form-compile.py
+++ b/.claude/skills/form-compile/scripts/form-compile.py
@@ -2999,6 +2999,34 @@ def main():
                     return False
         return True
 
+    # --- 1c. Validate unique element names (1C requirement) ---
+    def _collect_names(el, seen):
+        if not isinstance(el, dict):
+            return
+        type_key = None
+        for key in TYPE_KEYS:
+            if el.get(key) is not None:
+                type_key = key
+                break
+        if type_key:
+            el_name = get_element_name(el, type_key)
+            if el_name in seen:
+                print(f"[ERROR] Duplicate element name '{el_name}' — element names must be unique in 1C form", file=sys.stderr)
+                sys.exit(1)
+            seen.add(el_name)
+        for child in el.get('children', []):
+            _collect_names(child, seen)
+        for child in el.get('columns', []):
+            _collect_names(child, seen)
+
+    all_names = set()
+    if isinstance(defn.get('elements'), list):
+        for el in defn['elements']:
+            _collect_names(el, all_names)
+    if main_acb_def and isinstance(main_acb_def.get('children'), list):
+        for el in main_acb_def['children']:
+            _collect_names(el, all_names)
+
     # --- 2. Main compilation ---
     _next_id = 0
     lines = []

--- a/.claude/skills/form-edit/scripts/form-edit.ps1
+++ b/.claude/skills/form-edit/scripts/form-edit.ps1
@@ -864,7 +864,27 @@ if ($def.elements -and $def.elements.Count -gt 0) {
 	# Detect indent level
 	$childIndent = Get-ChildIndent $targetCI
 
-	# Check for duplicate element names
+	# Check for duplicate element names within the JSON definition itself
+	function Walk-Names($el, [hashtable]$seen) {
+		$typeKey = $null
+		foreach ($key in @("group","input","check","label","labelField","table","pages","page","button","picture","picField","calendar","cmdBar","popup")) {
+			if ($el.$key -ne $null) { $typeKey = $key; break }
+		}
+		if ($typeKey) {
+			$elName = Get-ElementName -el $el -typeKey $typeKey
+			if ($seen.ContainsKey($elName)) {
+				Write-Host "[ERROR] Duplicate element name '$elName' in JSON definition — element names must be unique in 1C form"
+				exit 1
+			}
+			$seen[$elName] = $true
+		}
+		if ($el.children) { foreach ($child in $el.children) { Walk-Names $child $seen } }
+		if ($el.columns) { foreach ($child in $el.columns) { Walk-Names $child $seen } }
+	}
+	$dslNames = @{}
+	foreach ($el in $def.elements) { Walk-Names $el $dslNames }
+
+	# Check for duplicate names against existing form elements
 	foreach ($el in $def.elements) {
 		$typeKey = $null
 		foreach ($key in @("group","input","check","label","labelField","table","pages","page","button","picture","picField","calendar","cmdBar","popup")) {
@@ -874,7 +894,8 @@ if ($def.elements -and $def.elements.Count -gt 0) {
 			$elName = Get-ElementName -el $el -typeKey $typeKey
 			$existing = Find-Element $rootCI $elName
 			if ($existing) {
-				Write-Host "[WARN] Element '$elName' already exists in form (id=$($existing.GetAttribute('id')))"
+				Write-Host "[ERROR] Element '$elName' already exists in form (id=$($existing.GetAttribute('id'))) — element names must be unique"
+				exit 1
 			}
 		}
 	}

--- a/.claude/skills/form-edit/scripts/form-edit.py
+++ b/.claude/skills/form-edit/scripts/form-edit.py
@@ -988,7 +988,29 @@ if elements_list:
     # Detect indent level
     child_indent = get_child_indent(target_ci)
 
-    # Check for duplicate element names
+    # Check for duplicate element names within the JSON definition itself
+    def _walk_names(el, seen):
+        type_key = None
+        for key in ELEMENT_KEYS:
+            if key in el and el[key] is not None:
+                type_key = key
+                break
+        if type_key:
+            el_name = get_element_name(el, type_key)
+            if el_name in seen:
+                print(f"[ERROR] Duplicate element name '{el_name}' in JSON definition — element names must be unique in 1C form")
+                sys.exit(1)
+            seen.add(el_name)
+        for child in el.get('children', []):
+            _walk_names(child, seen)
+        for child in el.get('columns', []):
+            _walk_names(child, seen)
+
+    dsl_names = set()
+    for el in elements_list:
+        _walk_names(el, dsl_names)
+
+    # Check for duplicate names against existing form elements
     for el in elements_list:
         type_key = None
         for key in ELEMENT_KEYS:
@@ -999,7 +1021,8 @@ if elements_list:
             el_name = get_element_name(el, type_key)
             existing = find_element(root_ci, el_name) if root_ci is not None else None
             if existing is not None:
-                print(f"[WARN] Element '{el_name}' already exists in form (id={existing.get('id')})")
+                print(f"[ERROR] Element '{el_name}' already exists in form (id={existing.get('id')}) — element names must be unique")
+                sys.exit(1)
 
     # Remember starting element ID for companion counting
     start_elem_id = next_elem_id

--- a/.claude/skills/form-validate/scripts/form-validate.ps1
+++ b/.claude/skills/form-validate/scripts/form-validate.ps1
@@ -156,6 +156,7 @@ if (-not $stopped) {
 # --- Collect all elements with IDs ---
 
 $elementIds = @{}  # id -> name (element ID pool)
+$elementNames = @{}  # name -> id (element name uniqueness)
 $allElements = @() # @{Name; Tag; Id; ParentName; Node}
 
 function Collect-Elements {
@@ -184,6 +185,13 @@ function Collect-Elements {
 					Report-Error "Duplicate element id=${id}: '$name' and '$($elementIds[$id])'"
 				} else {
 					$elementIds[$id] = $name
+				}
+
+				# Check duplicate names (1C requirement)
+				if ($elementNames.ContainsKey($name)) {
+					Report-Error "Duplicate element name '$name': id=${id} and id=$($elementNames[$name])"
+				} else {
+					$elementNames[$name] = $id
 				}
 			}
 

--- a/.claude/skills/form-validate/scripts/form-validate.py
+++ b/.claude/skills/form-validate/scripts/form-validate.py
@@ -183,6 +183,7 @@ def main():
 
     # --- Collect all elements with IDs ---
     element_ids = {}  # id -> name
+    element_names = {}  # name -> id
     all_elements = []  # list of dicts {Name, Tag, Id, ParentName, Node}
 
     def collect_elements(node, parent_name):
@@ -210,6 +211,12 @@ def main():
                         report_error(f"Duplicate element id={eid}: '{name}' and '{element_ids[eid]}'")
                     else:
                         element_ids[eid] = name
+
+                    # Check duplicate names (1C requirement)
+                    if name in element_names:
+                        report_error(f"Duplicate element name '{name}': id={eid} and id={element_names[name]}")
+                    else:
+                        element_names[name] = eid
 
                 child_items = child.find(f"{{{F_NS}}}ChildItems")
                 if child_items is not None:


### PR DESCRIPTION
## Описание

При генерации форм 1С через form-compile или form-edit, если в JSON-определении присутствовали элементы с одинаковыми именами, скрипты не сообщали об ошибке. В результате создавался некорректный Form.xml — 1С не допускает дубликатов имён элементов в форме.

Проблема проявлялась на этапе использования: форма не открывалась, ошибка была неочевидной.

## Что изменено

### form-compile (Python + PowerShell)
Добавлена функция `_collect_names`/`Validate-UniqueNames`, которая перед генерацией XML рекурсивно обходит массив `elements`, `children` групп, `columns` таблиц, а также `autoCmdBar`. При обнаружении дубликата — `[ERROR]` и `exit(1)`.

### form-edit (Python + PowerShell)
- Добавлена проверка дубликатов **внутри** JSON-определения (рекурсивно по `children`/`columns`)
- Проверка дубликатов **против существующих элементов формы** — была `[WARN]`, стала `[ERROR]` + `exit(1)`

### form-validate (Python + PowerShell)
Добавлена проверка уникальности имён элементов (помимо существовавшей проверки уникальности ID). При дубликате — `[ERROR] Duplicate element name 'X': id=N and id=M`.

## Затронутые файлы

- `.claude/skills/form-compile/scripts/form-compile.py`
- `.claude/skills/form-compile/scripts/form-compile.ps1`
- `.claude/skills/form-edit/scripts/form-edit.py`
- `.claude/skills/form-edit/scripts/form-edit.ps1`
- `.claude/skills/form-validate/scripts/form-validate.py`
- `.claude/skills/form-validate/scripts/form-validate.ps1`

## Проверка

Все три скрипта протестированы с дублирующимися именами — каждый корректно завершается с ошибкой. Тесты выполнялись вручную через Python и PowerShell (ExecutionPolicy Bypass).

## Тип изменений

- [x] Bug fix