### PR TITLE
web-publish: исправление публикации OData в default.vrd

### DIFF
--- a/.claude/skills/web-publish/scripts/web-publish.ps1
+++ b/.claude/skills/web-publish/scripts/web-publish.ps1
@@ -278,8 +278,8 @@ $vrdContent = @"
        xmlns:xs="http://www.w3.org/2001/XMLSchema"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        base="/$AppName"
-       ib="$ibString"
-       enableStandardOdata="true">
+       ib="$ibString">
+    <standardOdata enable="true"/>
     <ws pointEnableCommon="true"/>
     <httpServices publishByDefault="true"/>
 </point>

--- a/.claude/skills/web-publish/scripts/web-publish.py
+++ b/.claude/skills/web-publish/scripts/web-publish.py
@@ -297,8 +297,8 @@ def main():
        xmlns:xs="http://www.w3.org/2001/XMLSchema"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        base="/{app_name}"
-       ib="{ib_string}"
-       enableStandardOdata="true">
+       ib="{ib_string}">
+    <standardOdata enable="true"/>
     <ws pointEnableCommon="true"/>
     <httpServices publishByDefault="true"/>
 </point>'''


### PR DESCRIPTION
## Проблема

Стандартный интерфейс OData объявлялся в `default.vrd` через **несуществующий атрибут** `enableStandardOdata="true"` на элементе `<point>`. В результате OData возвращал **HTTP 404** («1C:Enterprise 8 application error: HTTP: Not found») при обращении к `…/odata/standard.odata/`, хотя публикация выглядела включённой (и веб-клиент/HTTP-сервисы работали).

## Исправление

Корректная форма в vrd — дочерний элемент `<standardOdata enable="true"/>`:

```diff
        base="/{app_name}"
-       ib="{ib_string}"
-       enableStandardOdata="true">
+       ib="{ib_string}">
+    <standardOdata enable="true"/>
     <ws pointEnableCommon="true"/>
     <httpServices publishByDefault="true"/>
 </point>
```

Исправлено идентично в обеих реализациях (`web-publish.ps1` и `web-publish.py`).

## Проверка

На живой файловой базе после фикса (с непустым составом стандартного интерфейса OData) сервис-документ и сущности отдаются с **HTTP 200** (раньше — 404):
```
GET http://localhost:<port>/<app>/odata/standard.odata/?$format=json   → 200
```