### PR TITLE
Исправить запуск Python-скриптов навыков на macOS

### DIFF
--- a/.claude/skills/db-create/scripts/db-create.py
+++ b/.claude/skills/db-create/scripts/db-create.py
@@ -36,32 +36,61 @@ def _find_project_v8path():
         d = parent
 
 
+def _version_dir(p):
+    """Return version dir for both Windows bin layout and Unix platform layout."""
+    parent = os.path.dirname(p)
+    if os.path.basename(parent).lower() == "bin":
+        parent = os.path.dirname(parent)
+    return os.path.basename(parent)
+
+
 def _version_key(p):
-    """Numeric sort key from version dir name (.../1cv8/<ver>/bin/1cv8.exe)."""
-    ver = os.path.basename(os.path.dirname(os.path.dirname(p)))
-    return [int(x) for x in re.findall(r"\d+", ver)]
+    """Numeric sort key from version dir name (.../1cv8/<ver>/1cv8)."""
+    return [int(x) for x in re.findall(r"\d+", _version_dir(p))]
 
 
-def resolve_v8path(v8path):
-    """Resolve path to 1cv8.exe."""
-    if not v8path:
-        v8path = _find_project_v8path()
-    if not v8path:
-        candidates = (
+def _v8_executable_names():
+    if os.name == "nt":
+        return ["1cv8.exe", "1cv8c.exe", "ibcmd.exe"]
+    return ["1cv8", "1cv8c", "ibcmd"]
+
+
+def _v8_candidates():
+    if os.name == "nt":
+        return (
             glob.glob(r"C:\Program Files\1cv8\*\bin\1cv8.exe")
             + glob.glob(r"C:\Program Files (x86)\1cv8\*\bin\1cv8.exe")
         )
+    candidates = []
+    for exe_name in _v8_executable_names():
+        candidates.extend(glob.glob(os.path.join("/opt/1cv8", "*", exe_name)))
+    return candidates
+
+
+def resolve_v8path(v8path):
+    """Resolve path to a 1C executable."""
+    if not v8path:
+        v8path = _find_project_v8path()
+    if not v8path:
+        candidates = _v8_candidates()
         if candidates:
             v8path = max(candidates, key=_version_key)
-            ver = os.path.basename(os.path.dirname(os.path.dirname(v8path)))
-            print(f"Auto-selected platform {ver}: {v8path}")
+            print(f"Auto-selected platform {_version_dir(v8path)}: {v8path}")
         else:
-            print("Error: 1cv8.exe not found. Specify -V8Path", file=sys.stderr)
+            print("Error: 1C executable not found. Specify -V8Path", file=sys.stderr)
             sys.exit(1)
     if os.path.isdir(v8path):
-        v8path = os.path.join(v8path, "1cv8.exe")
+        for exe_name in _v8_executable_names():
+            candidate = os.path.join(v8path, exe_name)
+            if os.path.isfile(candidate):
+                v8path = candidate
+                break
+        else:
+            tried = ", ".join(_v8_executable_names())
+            print(f"Error: 1C executable not found in {v8path} (tried: {tried})", file=sys.stderr)
+            sys.exit(1)
     if not os.path.isfile(v8path):
-        print(f"Error: 1cv8.exe not found at {v8path}", file=sys.stderr)
+        print(f"Error: 1C executable not found at {v8path}", file=sys.stderr)
         sys.exit(1)
     return v8path
 

--- a/.claude/skills/db-dump-cf/scripts/db-dump-cf.py
+++ b/.claude/skills/db-dump-cf/scripts/db-dump-cf.py
@@ -36,32 +36,61 @@ def _find_project_v8path():
         d = parent
 
 
+def _version_dir(p):
+    """Return version dir for both Windows bin layout and Unix platform layout."""
+    parent = os.path.dirname(p)
+    if os.path.basename(parent).lower() == "bin":
+        parent = os.path.dirname(parent)
+    return os.path.basename(parent)
+
+
 def _version_key(p):
-    """Numeric sort key from version dir name (.../1cv8/<ver>/bin/1cv8.exe)."""
-    ver = os.path.basename(os.path.dirname(os.path.dirname(p)))
-    return [int(x) for x in re.findall(r"\d+", ver)]
+    """Numeric sort key from version dir name (.../1cv8/<ver>/1cv8)."""
+    return [int(x) for x in re.findall(r"\d+", _version_dir(p))]
 
 
-def resolve_v8path(v8path):
-    """Resolve path to 1cv8.exe."""
-    if not v8path:
-        v8path = _find_project_v8path()
-    if not v8path:
-        candidates = (
+def _v8_executable_names():
+    if os.name == "nt":
+        return ["1cv8.exe", "1cv8c.exe", "ibcmd.exe"]
+    return ["1cv8", "1cv8c", "ibcmd"]
+
+
+def _v8_candidates():
+    if os.name == "nt":
+        return (
             glob.glob(r"C:\Program Files\1cv8\*\bin\1cv8.exe")
             + glob.glob(r"C:\Program Files (x86)\1cv8\*\bin\1cv8.exe")
         )
+    candidates = []
+    for exe_name in _v8_executable_names():
+        candidates.extend(glob.glob(os.path.join("/opt/1cv8", "*", exe_name)))
+    return candidates
+
+
+def resolve_v8path(v8path):
+    """Resolve path to a 1C executable."""
+    if not v8path:
+        v8path = _find_project_v8path()
+    if not v8path:
+        candidates = _v8_candidates()
         if candidates:
             v8path = max(candidates, key=_version_key)
-            ver = os.path.basename(os.path.dirname(os.path.dirname(v8path)))
-            print(f"Auto-selected platform {ver}: {v8path}")
+            print(f"Auto-selected platform {_version_dir(v8path)}: {v8path}")
         else:
-            print("Error: 1cv8.exe not found. Specify -V8Path", file=sys.stderr)
+            print("Error: 1C executable not found. Specify -V8Path", file=sys.stderr)
             sys.exit(1)
     if os.path.isdir(v8path):
-        v8path = os.path.join(v8path, "1cv8.exe")
+        for exe_name in _v8_executable_names():
+            candidate = os.path.join(v8path, exe_name)
+            if os.path.isfile(candidate):
+                v8path = candidate
+                break
+        else:
+            tried = ", ".join(_v8_executable_names())
+            print(f"Error: 1C executable not found in {v8path} (tried: {tried})", file=sys.stderr)
+            sys.exit(1)
     if not os.path.isfile(v8path):
-        print(f"Error: 1cv8.exe not found at {v8path}", file=sys.stderr)
+        print(f"Error: 1C executable not found at {v8path}", file=sys.stderr)
         sys.exit(1)
     return v8path
 

--- a/.claude/skills/db-dump-dt/scripts/db-dump-dt.py
+++ b/.claude/skills/db-dump-dt/scripts/db-dump-dt.py
@@ -36,32 +36,61 @@ def _find_project_v8path():
         d = parent
 
 
+def _version_dir(p):
+    """Return version dir for both Windows bin layout and Unix platform layout."""
+    parent = os.path.dirname(p)
+    if os.path.basename(parent).lower() == "bin":
+        parent = os.path.dirname(parent)
+    return os.path.basename(parent)
+
+
 def _version_key(p):
-    """Numeric sort key from version dir name (.../1cv8/<ver>/bin/1cv8.exe)."""
-    ver = os.path.basename(os.path.dirname(os.path.dirname(p)))
-    return [int(x) for x in re.findall(r"\d+", ver)]
+    """Numeric sort key from version dir name (.../1cv8/<ver>/1cv8)."""
+    return [int(x) for x in re.findall(r"\d+", _version_dir(p))]
 
 
-def resolve_v8path(v8path):
-    """Resolve path to 1cv8.exe."""
-    if not v8path:
-        v8path = _find_project_v8path()
-    if not v8path:
-        candidates = (
+def _v8_executable_names():
+    if os.name == "nt":
+        return ["1cv8.exe", "1cv8c.exe", "ibcmd.exe"]
+    return ["1cv8", "1cv8c", "ibcmd"]
+
+
+def _v8_candidates():
+    if os.name == "nt":
+        return (
             glob.glob(r"C:\Program Files\1cv8\*\bin\1cv8.exe")
             + glob.glob(r"C:\Program Files (x86)\1cv8\*\bin\1cv8.exe")
         )
+    candidates = []
+    for exe_name in _v8_executable_names():
+        candidates.extend(glob.glob(os.path.join("/opt/1cv8", "*", exe_name)))
+    return candidates
+
+
+def resolve_v8path(v8path):
+    """Resolve path to a 1C executable."""
+    if not v8path:
+        v8path = _find_project_v8path()
+    if not v8path:
+        candidates = _v8_candidates()
         if candidates:
             v8path = max(candidates, key=_version_key)
-            ver = os.path.basename(os.path.dirname(os.path.dirname(v8path)))
-            print(f"Auto-selected platform {ver}: {v8path}")
+            print(f"Auto-selected platform {_version_dir(v8path)}: {v8path}")
         else:
-            print("Error: 1cv8.exe not found. Specify -V8Path", file=sys.stderr)
+            print("Error: 1C executable not found. Specify -V8Path", file=sys.stderr)
             sys.exit(1)
     if os.path.isdir(v8path):
-        v8path = os.path.join(v8path, "1cv8.exe")
+        for exe_name in _v8_executable_names():
+            candidate = os.path.join(v8path, exe_name)
+            if os.path.isfile(candidate):
+                v8path = candidate
+                break
+        else:
+            tried = ", ".join(_v8_executable_names())
+            print(f"Error: 1C executable not found in {v8path} (tried: {tried})", file=sys.stderr)
+            sys.exit(1)
     if not os.path.isfile(v8path):
-        print(f"Error: 1cv8.exe not found at {v8path}", file=sys.stderr)
+        print(f"Error: 1C executable not found at {v8path}", file=sys.stderr)
         sys.exit(1)
     return v8path
 

--- a/.claude/skills/db-dump-xml/scripts/db-dump-xml.py
+++ b/.claude/skills/db-dump-xml/scripts/db-dump-xml.py
@@ -36,32 +36,61 @@ def _find_project_v8path():
         d = parent
 
 
+def _version_dir(p):
+    """Return version dir for both Windows bin layout and Unix platform layout."""
+    parent = os.path.dirname(p)
+    if os.path.basename(parent).lower() == "bin":
+        parent = os.path.dirname(parent)
+    return os.path.basename(parent)
+
+
 def _version_key(p):
-    """Numeric sort key from version dir name (.../1cv8/<ver>/bin/1cv8.exe)."""
-    ver = os.path.basename(os.path.dirname(os.path.dirname(p)))
-    return [int(x) for x in re.findall(r"\d+", ver)]
+    """Numeric sort key from version dir name (.../1cv8/<ver>/1cv8)."""
+    return [int(x) for x in re.findall(r"\d+", _version_dir(p))]
 
 
-def resolve_v8path(v8path):
-    """Resolve path to 1cv8.exe."""
-    if not v8path:
-        v8path = _find_project_v8path()
-    if not v8path:
-        candidates = (
+def _v8_executable_names():
+    if os.name == "nt":
+        return ["1cv8.exe", "1cv8c.exe", "ibcmd.exe"]
+    return ["1cv8", "1cv8c", "ibcmd"]
+
+
+def _v8_candidates():
+    if os.name == "nt":
+        return (
             glob.glob(r"C:\Program Files\1cv8\*\bin\1cv8.exe")
             + glob.glob(r"C:\Program Files (x86)\1cv8\*\bin\1cv8.exe")
         )
+    candidates = []
+    for exe_name in _v8_executable_names():
+        candidates.extend(glob.glob(os.path.join("/opt/1cv8", "*", exe_name)))
+    return candidates
+
+
+def resolve_v8path(v8path):
+    """Resolve path to a 1C executable."""
+    if not v8path:
+        v8path = _find_project_v8path()
+    if not v8path:
+        candidates = _v8_candidates()
         if candidates:
             v8path = max(candidates, key=_version_key)
-            ver = os.path.basename(os.path.dirname(os.path.dirname(v8path)))
-            print(f"Auto-selected platform {ver}: {v8path}")
+            print(f"Auto-selected platform {_version_dir(v8path)}: {v8path}")
         else:
-            print("Error: 1cv8.exe not found. Specify -V8Path", file=sys.stderr)
+            print("Error: 1C executable not found. Specify -V8Path", file=sys.stderr)
             sys.exit(1)
     if os.path.isdir(v8path):
-        v8path = os.path.join(v8path, "1cv8.exe")
+        for exe_name in _v8_executable_names():
+            candidate = os.path.join(v8path, exe_name)
+            if os.path.isfile(candidate):
+                v8path = candidate
+                break
+        else:
+            tried = ", ".join(_v8_executable_names())
+            print(f"Error: 1C executable not found in {v8path} (tried: {tried})", file=sys.stderr)
+            sys.exit(1)
     if not os.path.isfile(v8path):
-        print(f"Error: 1cv8.exe not found at {v8path}", file=sys.stderr)
+        print(f"Error: 1C executable not found at {v8path}", file=sys.stderr)
         sys.exit(1)
     return v8path
 

--- a/.claude/skills/db-load-cf/scripts/db-load-cf.py
+++ b/.claude/skills/db-load-cf/scripts/db-load-cf.py
@@ -36,32 +36,61 @@ def _find_project_v8path():
         d = parent
 
 
+def _version_dir(p):
+    """Return version dir for both Windows bin layout and Unix platform layout."""
+    parent = os.path.dirname(p)
+    if os.path.basename(parent).lower() == "bin":
+        parent = os.path.dirname(parent)
+    return os.path.basename(parent)
+
+
 def _version_key(p):
-    """Numeric sort key from version dir name (.../1cv8/<ver>/bin/1cv8.exe)."""
-    ver = os.path.basename(os.path.dirname(os.path.dirname(p)))
-    return [int(x) for x in re.findall(r"\d+", ver)]
+    """Numeric sort key from version dir name (.../1cv8/<ver>/1cv8)."""
+    return [int(x) for x in re.findall(r"\d+", _version_dir(p))]
 
 
-def resolve_v8path(v8path):
-    """Resolve path to 1cv8.exe."""
-    if not v8path:
-        v8path = _find_project_v8path()
-    if not v8path:
-        candidates = (
+def _v8_executable_names():
+    if os.name == "nt":
+        return ["1cv8.exe", "1cv8c.exe", "ibcmd.exe"]
+    return ["1cv8", "1cv8c", "ibcmd"]
+
+
+def _v8_candidates():
+    if os.name == "nt":
+        return (
             glob.glob(r"C:\Program Files\1cv8\*\bin\1cv8.exe")
             + glob.glob(r"C:\Program Files (x86)\1cv8\*\bin\1cv8.exe")
         )
+    candidates = []
+    for exe_name in _v8_executable_names():
+        candidates.extend(glob.glob(os.path.join("/opt/1cv8", "*", exe_name)))
+    return candidates
+
+
+def resolve_v8path(v8path):
+    """Resolve path to a 1C executable."""
+    if not v8path:
+        v8path = _find_project_v8path()
+    if not v8path:
+        candidates = _v8_candidates()
         if candidates:
             v8path = max(candidates, key=_version_key)
-            ver = os.path.basename(os.path.dirname(os.path.dirname(v8path)))
-            print(f"Auto-selected platform {ver}: {v8path}")
+            print(f"Auto-selected platform {_version_dir(v8path)}: {v8path}")
         else:
-            print("Error: 1cv8.exe not found. Specify -V8Path", file=sys.stderr)
+            print("Error: 1C executable not found. Specify -V8Path", file=sys.stderr)
             sys.exit(1)
     if os.path.isdir(v8path):
-        v8path = os.path.join(v8path, "1cv8.exe")
+        for exe_name in _v8_executable_names():
+            candidate = os.path.join(v8path, exe_name)
+            if os.path.isfile(candidate):
+                v8path = candidate
+                break
+        else:
+            tried = ", ".join(_v8_executable_names())
+            print(f"Error: 1C executable not found in {v8path} (tried: {tried})", file=sys.stderr)
+            sys.exit(1)
     if not os.path.isfile(v8path):
-        print(f"Error: 1cv8.exe not found at {v8path}", file=sys.stderr)
+        print(f"Error: 1C executable not found at {v8path}", file=sys.stderr)
         sys.exit(1)
     return v8path
 

--- a/.claude/skills/db-load-dt/scripts/db-load-dt.py
+++ b/.claude/skills/db-load-dt/scripts/db-load-dt.py
@@ -36,32 +36,61 @@ def _find_project_v8path():
         d = parent
 
 
+def _version_dir(p):
+    """Return version dir for both Windows bin layout and Unix platform layout."""
+    parent = os.path.dirname(p)
+    if os.path.basename(parent).lower() == "bin":
+        parent = os.path.dirname(parent)
+    return os.path.basename(parent)
+
+
 def _version_key(p):
-    """Numeric sort key from version dir name (.../1cv8/<ver>/bin/1cv8.exe)."""
-    ver = os.path.basename(os.path.dirname(os.path.dirname(p)))
-    return [int(x) for x in re.findall(r"\d+", ver)]
+    """Numeric sort key from version dir name (.../1cv8/<ver>/1cv8)."""
+    return [int(x) for x in re.findall(r"\d+", _version_dir(p))]
 
 
-def resolve_v8path(v8path):
-    """Resolve path to 1cv8.exe."""
-    if not v8path:
-        v8path = _find_project_v8path()
-    if not v8path:
-        candidates = (
+def _v8_executable_names():
+    if os.name == "nt":
+        return ["1cv8.exe", "1cv8c.exe", "ibcmd.exe"]
+    return ["1cv8", "1cv8c", "ibcmd"]
+
+
+def _v8_candidates():
+    if os.name == "nt":
+        return (
             glob.glob(r"C:\Program Files\1cv8\*\bin\1cv8.exe")
             + glob.glob(r"C:\Program Files (x86)\1cv8\*\bin\1cv8.exe")
         )
+    candidates = []
+    for exe_name in _v8_executable_names():
+        candidates.extend(glob.glob(os.path.join("/opt/1cv8", "*", exe_name)))
+    return candidates
+
+
+def resolve_v8path(v8path):
+    """Resolve path to a 1C executable."""
+    if not v8path:
+        v8path = _find_project_v8path()
+    if not v8path:
+        candidates = _v8_candidates()
         if candidates:
             v8path = max(candidates, key=_version_key)
-            ver = os.path.basename(os.path.dirname(os.path.dirname(v8path)))
-            print(f"Auto-selected platform {ver}: {v8path}")
+            print(f"Auto-selected platform {_version_dir(v8path)}: {v8path}")
         else:
-            print("Error: 1cv8.exe not found. Specify -V8Path", file=sys.stderr)
+            print("Error: 1C executable not found. Specify -V8Path", file=sys.stderr)
             sys.exit(1)
     if os.path.isdir(v8path):
-        v8path = os.path.join(v8path, "1cv8.exe")
+        for exe_name in _v8_executable_names():
+            candidate = os.path.join(v8path, exe_name)
+            if os.path.isfile(candidate):
+                v8path = candidate
+                break
+        else:
+            tried = ", ".join(_v8_executable_names())
+            print(f"Error: 1C executable not found in {v8path} (tried: {tried})", file=sys.stderr)
+            sys.exit(1)
     if not os.path.isfile(v8path):
-        print(f"Error: 1cv8.exe not found at {v8path}", file=sys.stderr)
+        print(f"Error: 1C executable not found at {v8path}", file=sys.stderr)
         sys.exit(1)
     return v8path
 

--- a/.claude/skills/db-load-git/scripts/db-load-git.py
+++ b/.claude/skills/db-load-git/scripts/db-load-git.py
@@ -36,32 +36,61 @@ def _find_project_v8path():
         d = parent
 
 
+def _version_dir(p):
+    """Return version dir for both Windows bin layout and Unix platform layout."""
+    parent = os.path.dirname(p)
+    if os.path.basename(parent).lower() == "bin":
+        parent = os.path.dirname(parent)
+    return os.path.basename(parent)
+
+
 def _version_key(p):
-    """Numeric sort key from version dir name (.../1cv8/<ver>/bin/1cv8.exe)."""
-    ver = os.path.basename(os.path.dirname(os.path.dirname(p)))
-    return [int(x) for x in re.findall(r"\d+", ver)]
+    """Numeric sort key from version dir name (.../1cv8/<ver>/1cv8)."""
+    return [int(x) for x in re.findall(r"\d+", _version_dir(p))]
 
 
-def resolve_v8path(v8path):
-    """Resolve path to 1cv8.exe."""
-    if not v8path:
-        v8path = _find_project_v8path()
-    if not v8path:
-        candidates = (
+def _v8_executable_names():
+    if os.name == "nt":
+        return ["1cv8.exe", "1cv8c.exe", "ibcmd.exe"]
+    return ["1cv8", "1cv8c", "ibcmd"]
+
+
+def _v8_candidates():
+    if os.name == "nt":
+        return (
             glob.glob(r"C:\Program Files\1cv8\*\bin\1cv8.exe")
             + glob.glob(r"C:\Program Files (x86)\1cv8\*\bin\1cv8.exe")
         )
+    candidates = []
+    for exe_name in _v8_executable_names():
+        candidates.extend(glob.glob(os.path.join("/opt/1cv8", "*", exe_name)))
+    return candidates
+
+
+def resolve_v8path(v8path):
+    """Resolve path to a 1C executable."""
+    if not v8path:
+        v8path = _find_project_v8path()
+    if not v8path:
+        candidates = _v8_candidates()
         if candidates:
             v8path = max(candidates, key=_version_key)
-            ver = os.path.basename(os.path.dirname(os.path.dirname(v8path)))
-            print(f"Auto-selected platform {ver}: {v8path}")
+            print(f"Auto-selected platform {_version_dir(v8path)}: {v8path}")
         else:
-            print("Error: 1cv8.exe not found. Specify -V8Path", file=sys.stderr)
+            print("Error: 1C executable not found. Specify -V8Path", file=sys.stderr)
             sys.exit(1)
     if os.path.isdir(v8path):
-        v8path = os.path.join(v8path, "1cv8.exe")
+        for exe_name in _v8_executable_names():
+            candidate = os.path.join(v8path, exe_name)
+            if os.path.isfile(candidate):
+                v8path = candidate
+                break
+        else:
+            tried = ", ".join(_v8_executable_names())
+            print(f"Error: 1C executable not found in {v8path} (tried: {tried})", file=sys.stderr)
+            sys.exit(1)
     if not os.path.isfile(v8path):
-        print(f"Error: 1cv8.exe not found at {v8path}", file=sys.stderr)
+        print(f"Error: 1C executable not found at {v8path}", file=sys.stderr)
         sys.exit(1)
     return v8path
 

--- a/.claude/skills/db-load-xml/scripts/db-load-xml.py
+++ b/.claude/skills/db-load-xml/scripts/db-load-xml.py
@@ -36,32 +36,61 @@ def _find_project_v8path():
         d = parent
 
 
+def _version_dir(p):
+    """Return version dir for both Windows bin layout and Unix platform layout."""
+    parent = os.path.dirname(p)
+    if os.path.basename(parent).lower() == "bin":
+        parent = os.path.dirname(parent)
+    return os.path.basename(parent)
+
+
 def _version_key(p):
-    """Numeric sort key from version dir name (.../1cv8/<ver>/bin/1cv8.exe)."""
-    ver = os.path.basename(os.path.dirname(os.path.dirname(p)))
-    return [int(x) for x in re.findall(r"\d+", ver)]
+    """Numeric sort key from version dir name (.../1cv8/<ver>/1cv8)."""
+    return [int(x) for x in re.findall(r"\d+", _version_dir(p))]
 
 
-def resolve_v8path(v8path):
-    """Resolve path to 1cv8.exe."""
-    if not v8path:
-        v8path = _find_project_v8path()
-    if not v8path:
-        candidates = (
+def _v8_executable_names():
+    if os.name == "nt":
+        return ["1cv8.exe", "1cv8c.exe", "ibcmd.exe"]
+    return ["1cv8", "1cv8c", "ibcmd"]
+
+
+def _v8_candidates():
+    if os.name == "nt":
+        return (
             glob.glob(r"C:\Program Files\1cv8\*\bin\1cv8.exe")
             + glob.glob(r"C:\Program Files (x86)\1cv8\*\bin\1cv8.exe")
         )
+    candidates = []
+    for exe_name in _v8_executable_names():
+        candidates.extend(glob.glob(os.path.join("/opt/1cv8", "*", exe_name)))
+    return candidates
+
+
+def resolve_v8path(v8path):
+    """Resolve path to a 1C executable."""
+    if not v8path:
+        v8path = _find_project_v8path()
+    if not v8path:
+        candidates = _v8_candidates()
         if candidates:
             v8path = max(candidates, key=_version_key)
-            ver = os.path.basename(os.path.dirname(os.path.dirname(v8path)))
-            print(f"Auto-selected platform {ver}: {v8path}")
+            print(f"Auto-selected platform {_version_dir(v8path)}: {v8path}")
         else:
-            print("Error: 1cv8.exe not found. Specify -V8Path", file=sys.stderr)
+            print("Error: 1C executable not found. Specify -V8Path", file=sys.stderr)
             sys.exit(1)
     if os.path.isdir(v8path):
-        v8path = os.path.join(v8path, "1cv8.exe")
+        for exe_name in _v8_executable_names():
+            candidate = os.path.join(v8path, exe_name)
+            if os.path.isfile(candidate):
+                v8path = candidate
+                break
+        else:
+            tried = ", ".join(_v8_executable_names())
+            print(f"Error: 1C executable not found in {v8path} (tried: {tried})", file=sys.stderr)
+            sys.exit(1)
     if not os.path.isfile(v8path):
-        print(f"Error: 1cv8.exe not found at {v8path}", file=sys.stderr)
+        print(f"Error: 1C executable not found at {v8path}", file=sys.stderr)
         sys.exit(1)
     return v8path
 

--- a/.claude/skills/db-run/scripts/db-run.py
+++ b/.claude/skills/db-run/scripts/db-run.py
@@ -32,32 +32,61 @@ def _find_project_v8path():
         d = parent
 
 
+def _version_dir(p):
+    """Return version dir for both Windows bin layout and Unix platform layout."""
+    parent = os.path.dirname(p)
+    if os.path.basename(parent).lower() == "bin":
+        parent = os.path.dirname(parent)
+    return os.path.basename(parent)
+
+
 def _version_key(p):
-    """Numeric sort key from version dir name (.../1cv8/<ver>/bin/1cv8.exe)."""
-    ver = os.path.basename(os.path.dirname(os.path.dirname(p)))
-    return [int(x) for x in re.findall(r"\d+", ver)]
+    """Numeric sort key from version dir name (.../1cv8/<ver>/1cv8)."""
+    return [int(x) for x in re.findall(r"\d+", _version_dir(p))]
 
 
-def resolve_v8path(v8path):
-    """Resolve path to 1cv8.exe."""
-    if not v8path:
-        v8path = _find_project_v8path()
-    if not v8path:
-        candidates = (
+def _v8_executable_names():
+    if os.name == "nt":
+        return ["1cv8.exe", "1cv8c.exe", "ibcmd.exe"]
+    return ["1cv8", "1cv8c", "ibcmd"]
+
+
+def _v8_candidates():
+    if os.name == "nt":
+        return (
             glob.glob(r"C:\Program Files\1cv8\*\bin\1cv8.exe")
             + glob.glob(r"C:\Program Files (x86)\1cv8\*\bin\1cv8.exe")
         )
+    candidates = []
+    for exe_name in _v8_executable_names():
+        candidates.extend(glob.glob(os.path.join("/opt/1cv8", "*", exe_name)))
+    return candidates
+
+
+def resolve_v8path(v8path):
+    """Resolve path to a 1C executable."""
+    if not v8path:
+        v8path = _find_project_v8path()
+    if not v8path:
+        candidates = _v8_candidates()
         if candidates:
             v8path = max(candidates, key=_version_key)
-            ver = os.path.basename(os.path.dirname(os.path.dirname(v8path)))
-            print(f"Auto-selected platform {ver}: {v8path}")
+            print(f"Auto-selected platform {_version_dir(v8path)}: {v8path}")
         else:
-            print("Error: 1cv8.exe not found. Specify -V8Path", file=sys.stderr)
+            print("Error: 1C executable not found. Specify -V8Path", file=sys.stderr)
             sys.exit(1)
     if os.path.isdir(v8path):
-        v8path = os.path.join(v8path, "1cv8.exe")
+        for exe_name in _v8_executable_names():
+            candidate = os.path.join(v8path, exe_name)
+            if os.path.isfile(candidate):
+                v8path = candidate
+                break
+        else:
+            tried = ", ".join(_v8_executable_names())
+            print(f"Error: 1C executable not found in {v8path} (tried: {tried})", file=sys.stderr)
+            sys.exit(1)
     if not os.path.isfile(v8path):
-        print(f"Error: 1cv8.exe not found at {v8path}", file=sys.stderr)
+        print(f"Error: 1C executable not found at {v8path}", file=sys.stderr)
         sys.exit(1)
     return v8path
 

--- a/.claude/skills/db-update/scripts/db-update.py
+++ b/.claude/skills/db-update/scripts/db-update.py
@@ -36,32 +36,61 @@ def _find_project_v8path():
         d = parent
 
 
+def _version_dir(p):
+    """Return version dir for both Windows bin layout and Unix platform layout."""
+    parent = os.path.dirname(p)
+    if os.path.basename(parent).lower() == "bin":
+        parent = os.path.dirname(parent)
+    return os.path.basename(parent)
+
+
 def _version_key(p):
-    """Numeric sort key from version dir name (.../1cv8/<ver>/bin/1cv8.exe)."""
-    ver = os.path.basename(os.path.dirname(os.path.dirname(p)))
-    return [int(x) for x in re.findall(r"\d+", ver)]
+    """Numeric sort key from version dir name (.../1cv8/<ver>/1cv8)."""
+    return [int(x) for x in re.findall(r"\d+", _version_dir(p))]
 
 
-def resolve_v8path(v8path):
-    """Resolve path to 1cv8.exe."""
-    if not v8path:
-        v8path = _find_project_v8path()
-    if not v8path:
-        candidates = (
+def _v8_executable_names():
+    if os.name == "nt":
+        return ["1cv8.exe", "1cv8c.exe", "ibcmd.exe"]
+    return ["1cv8", "1cv8c", "ibcmd"]
+
+
+def _v8_candidates():
+    if os.name == "nt":
+        return (
             glob.glob(r"C:\Program Files\1cv8\*\bin\1cv8.exe")
             + glob.glob(r"C:\Program Files (x86)\1cv8\*\bin\1cv8.exe")
         )
+    candidates = []
+    for exe_name in _v8_executable_names():
+        candidates.extend(glob.glob(os.path.join("/opt/1cv8", "*", exe_name)))
+    return candidates
+
+
+def resolve_v8path(v8path):
+    """Resolve path to a 1C executable."""
+    if not v8path:
+        v8path = _find_project_v8path()
+    if not v8path:
+        candidates = _v8_candidates()
         if candidates:
             v8path = max(candidates, key=_version_key)
-            ver = os.path.basename(os.path.dirname(os.path.dirname(v8path)))
-            print(f"Auto-selected platform {ver}: {v8path}")
+            print(f"Auto-selected platform {_version_dir(v8path)}: {v8path}")
         else:
-            print("Error: 1cv8.exe not found. Specify -V8Path", file=sys.stderr)
+            print("Error: 1C executable not found. Specify -V8Path", file=sys.stderr)
             sys.exit(1)
     if os.path.isdir(v8path):
-        v8path = os.path.join(v8path, "1cv8.exe")
+        for exe_name in _v8_executable_names():
+            candidate = os.path.join(v8path, exe_name)
+            if os.path.isfile(candidate):
+                v8path = candidate
+                break
+        else:
+            tried = ", ".join(_v8_executable_names())
+            print(f"Error: 1C executable not found in {v8path} (tried: {tried})", file=sys.stderr)
+            sys.exit(1)
     if not os.path.isfile(v8path):
-        print(f"Error: 1cv8.exe not found at {v8path}", file=sys.stderr)
+        print(f"Error: 1C executable not found at {v8path}", file=sys.stderr)
         sys.exit(1)
     return v8path
 

--- a/.claude/skills/epf-build/scripts/epf-build.py
+++ b/.claude/skills/epf-build/scripts/epf-build.py
@@ -36,32 +36,61 @@ def _find_project_v8path():
         d = parent
 
 
+def _version_dir(p):
+    """Return version dir for both Windows bin layout and Unix platform layout."""
+    parent = os.path.dirname(p)
+    if os.path.basename(parent).lower() == "bin":
+        parent = os.path.dirname(parent)
+    return os.path.basename(parent)
+
+
 def _version_key(p):
-    """Numeric sort key from version dir name (.../1cv8/<ver>/bin/1cv8.exe)."""
-    ver = os.path.basename(os.path.dirname(os.path.dirname(p)))
-    return [int(x) for x in re.findall(r"\d+", ver)]
+    """Numeric sort key from version dir name (.../1cv8/<ver>/1cv8)."""
+    return [int(x) for x in re.findall(r"\d+", _version_dir(p))]
 
 
-def resolve_v8path(v8path):
-    """Resolve path to 1cv8.exe."""
-    if not v8path:
-        v8path = _find_project_v8path()
-    if not v8path:
-        candidates = (
+def _v8_executable_names():
+    if os.name == "nt":
+        return ["1cv8.exe", "1cv8c.exe", "ibcmd.exe"]
+    return ["1cv8", "1cv8c", "ibcmd"]
+
+
+def _v8_candidates():
+    if os.name == "nt":
+        return (
             glob.glob(r"C:\Program Files\1cv8\*\bin\1cv8.exe")
             + glob.glob(r"C:\Program Files (x86)\1cv8\*\bin\1cv8.exe")
         )
+    candidates = []
+    for exe_name in _v8_executable_names():
+        candidates.extend(glob.glob(os.path.join("/opt/1cv8", "*", exe_name)))
+    return candidates
+
+
+def resolve_v8path(v8path):
+    """Resolve path to a 1C executable."""
+    if not v8path:
+        v8path = _find_project_v8path()
+    if not v8path:
+        candidates = _v8_candidates()
         if candidates:
             v8path = max(candidates, key=_version_key)
-            ver = os.path.basename(os.path.dirname(os.path.dirname(v8path)))
-            print(f"Auto-selected platform {ver}: {v8path}")
+            print(f"Auto-selected platform {_version_dir(v8path)}: {v8path}")
         else:
-            print("Error: 1cv8.exe not found. Specify -V8Path", file=sys.stderr)
+            print("Error: 1C executable not found. Specify -V8Path", file=sys.stderr)
             sys.exit(1)
     if os.path.isdir(v8path):
-        v8path = os.path.join(v8path, "1cv8.exe")
+        for exe_name in _v8_executable_names():
+            candidate = os.path.join(v8path, exe_name)
+            if os.path.isfile(candidate):
+                v8path = candidate
+                break
+        else:
+            tried = ", ".join(_v8_executable_names())
+            print(f"Error: 1C executable not found in {v8path} (tried: {tried})", file=sys.stderr)
+            sys.exit(1)
     if not os.path.isfile(v8path):
-        print(f"Error: 1cv8.exe not found at {v8path}", file=sys.stderr)
+        print(f"Error: 1C executable not found at {v8path}", file=sys.stderr)
         sys.exit(1)
     return v8path
 

--- a/.claude/skills/epf-dump/scripts/epf-dump.py
+++ b/.claude/skills/epf-dump/scripts/epf-dump.py
@@ -36,32 +36,61 @@ def _find_project_v8path():
         d = parent
 
 
+def _version_dir(p):
+    """Return version dir for both Windows bin layout and Unix platform layout."""
+    parent = os.path.dirname(p)
+    if os.path.basename(parent).lower() == "bin":
+        parent = os.path.dirname(parent)
+    return os.path.basename(parent)
+
+
 def _version_key(p):
-    """Numeric sort key from version dir name (.../1cv8/<ver>/bin/1cv8.exe)."""
-    ver = os.path.basename(os.path.dirname(os.path.dirname(p)))
-    return [int(x) for x in re.findall(r"\d+", ver)]
+    """Numeric sort key from version dir name (.../1cv8/<ver>/1cv8)."""
+    return [int(x) for x in re.findall(r"\d+", _version_dir(p))]
 
 
-def resolve_v8path(v8path):
-    """Resolve path to 1cv8.exe."""
-    if not v8path:
-        v8path = _find_project_v8path()
-    if not v8path:
-        candidates = (
+def _v8_executable_names():
+    if os.name == "nt":
+        return ["1cv8.exe", "1cv8c.exe", "ibcmd.exe"]
+    return ["1cv8", "1cv8c", "ibcmd"]
+
+
+def _v8_candidates():
+    if os.name == "nt":
+        return (
             glob.glob(r"C:\Program Files\1cv8\*\bin\1cv8.exe")
             + glob.glob(r"C:\Program Files (x86)\1cv8\*\bin\1cv8.exe")
         )
+    candidates = []
+    for exe_name in _v8_executable_names():
+        candidates.extend(glob.glob(os.path.join("/opt/1cv8", "*", exe_name)))
+    return candidates
+
+
+def resolve_v8path(v8path):
+    """Resolve path to a 1C executable."""
+    if not v8path:
+        v8path = _find_project_v8path()
+    if not v8path:
+        candidates = _v8_candidates()
         if candidates:
             v8path = max(candidates, key=_version_key)
-            ver = os.path.basename(os.path.dirname(os.path.dirname(v8path)))
-            print(f"Auto-selected platform {ver}: {v8path}")
+            print(f"Auto-selected platform {_version_dir(v8path)}: {v8path}")
         else:
-            print("Error: 1cv8.exe not found. Specify -V8Path", file=sys.stderr)
+            print("Error: 1C executable not found. Specify -V8Path", file=sys.stderr)
             sys.exit(1)
     if os.path.isdir(v8path):
-        v8path = os.path.join(v8path, "1cv8.exe")
+        for exe_name in _v8_executable_names():
+            candidate = os.path.join(v8path, exe_name)
+            if os.path.isfile(candidate):
+                v8path = candidate
+                break
+        else:
+            tried = ", ".join(_v8_executable_names())
+            print(f"Error: 1C executable not found in {v8path} (tried: {tried})", file=sys.stderr)
+            sys.exit(1)
     if not os.path.isfile(v8path):
-        print(f"Error: 1cv8.exe not found at {v8path}", file=sys.stderr)
+        print(f"Error: 1C executable not found at {v8path}", file=sys.stderr)
         sys.exit(1)
     return v8path
 

--- a/.claude/skills/subsystem-compile/scripts/subsystem-compile.py
+++ b/.claude/skills/subsystem-compile/scripts/subsystem-compile.py
@@ -5,6 +5,7 @@ import argparse
 import json
 import os
 import re
+import subprocess
 import sys
 import uuid
 import xml.etree.ElementTree as ET
@@ -591,11 +592,13 @@ def main():
     # --- 6. Auto-validate ---
     if not args.NoValidate:
         script_dir = os.path.dirname(os.path.abspath(__file__))
-        validate_script = os.path.normpath(os.path.join(script_dir, '..', '..', 'subsystem-validate', 'scripts', 'subsystem-validate.ps1'))
-        if os.path.exists(validate_script):
+        validate_script = os.path.normpath(os.path.join(script_dir, '..', '..', 'subsystem-validate', 'scripts', 'subsystem-validate.py'))
+        if os.path.isfile(validate_script):
             print()
             print("--- Running subsystem-validate ---")
-            os.system(f'powershell.exe -NoProfile -File "{validate_script}" -SubsystemPath "{target_xml}"')
+            result = subprocess.run([sys.executable, validate_script, "-SubsystemPath", target_xml])
+            if result.returncode != 0:
+                sys.exit(result.returncode)
 
     # --- 7. Summary ---
     print()

--- a/tests/skills/macos-python-scripts.test.mjs
+++ b/tests/skills/macos-python-scripts.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '../..');
+const PYTHON = process.env.PYTHON || 'python3';
+
+function runPython(script, args, options = {}) {
+  return spawnSync(PYTHON, [script, ...args], {
+    cwd: ROOT,
+    encoding: 'utf8',
+    ...options,
+  });
+}
+
+test('subsystem-compile python port validates via python, not powershell.exe', { skip: process.platform === 'win32' }, () => {
+  const workDir = mkdtempSync(join(tmpdir(), 'skill-subsystem-'));
+  const inputFile = join(workDir, 'subsystem.json');
+  writeFileSync(inputFile, JSON.stringify({ name: 'Тест' }), 'utf8');
+
+  try {
+    const result = runPython(
+      join(ROOT, '.claude/skills/subsystem-compile/scripts/subsystem-compile.py'),
+      ['-DefinitionFile', inputFile, '-OutputDir', workDir],
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.doesNotMatch(result.stderr, /powershell\.exe/i);
+  } finally {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+test('db-update accepts a macOS platform directory containing 1cv8', { skip: process.platform === 'win32' }, () => {
+  const tempDir = mkdtempSync(join(tmpdir(), 'skill-v8path-'));
+  const binDir = join(tempDir, 'platform');
+  const fake1cv8 = join(binDir, '1cv8');
+  const infoBaseDir = join(tempDir, 'ib');
+  const markerFile = join(tempDir, 'called');
+
+  try {
+    mkdirSync(binDir, { recursive: true });
+    mkdirSync(infoBaseDir, { recursive: true });
+    writeFileSync(fake1cv8, `#!/bin/sh\ntouch "${markerFile}"\nexit 0\n`, 'utf8');
+    chmodSync(fake1cv8, 0o755);
+
+    const result = runPython(
+      join(ROOT, '.claude/skills/db-update/scripts/db-update.py'),
+      ['-V8Path', binDir, '-InfoBasePath', infoBaseDir],
+    );
+
+    assert.equal(result.status, 0, result.stderr || result.stdout);
+    assert.equal(existsSync(markerFile), true);
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Что сделано

- `subsystem-compile.py` запускает Python-валидатор `subsystem-validate.py` через текущий интерпретатор вместо `powershell.exe`.
- 12 DB/EPF Python-скриптов теперь корректно разрешают каталог платформы на macOS/Linux: `1cv8`, `1cv8c`, `ibcmd` без `.exe`.
- Добавлен регрессионный тест `tests/skills/macos-python-scripts.test.mjs`, который воспроизводит оба macOS-сценария.

Fixes #26
Fixes #27

## Проверки

- `env PYTHON=/Users/korolev/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 node --test tests/skills/macos-python-scripts.test.mjs` — 2/2 passed.
- `python3 -m py_compile` для измененных Python-скриптов — exit code 0.
- `node tests/skills/runner.mjs subsystem-compile --runtime python --concurrency 2` — 9/9 passed.
- `node tests/skills/runner.mjs db-update --runtime python --concurrency 1` — 1/1 passed.
- Полный Python-прогон: integration 8/8; snapshot 422 passed / 1 failed / 36 skipped / 459 total. Единственный fail прежний: `help-add/guard-deny`, он не связан с этими изменениями и похож на проблему тестовой фикстуры.

## Не входит в этот PR

- #28: `db-*` + `ibcmd` без `-UserName` может зависать на macOS. Это отдельная проблема non-interactive auth handling, ее лучше чинить отдельным дизайном и PR.