### PR TITLE
fix(subsystem-compile): keep validator invocation shell-free

### DIFF
--- a/.claude/skills/subsystem-compile/scripts/subsystem-compile.py
+++ b/.claude/skills/subsystem-compile/scripts/subsystem-compile.py
@@ -596,7 +596,12 @@ def main():
         if os.path.isfile(validate_script):
             print()
             print("--- Running subsystem-validate ---")
-            subprocess.run([sys.executable, validate_script, "-SubsystemPath", target_xml])
+            # Keep target_xml as an argv element; do not build a shell command line.
+            subprocess.run(
+                [sys.executable, validate_script, "-SubsystemPath", target_xml],
+                check=False,
+                shell=False,
+            )
 
     # --- 7. Summary ---
     print()


### PR DESCRIPTION
## Summary
- keeps subsystem-validate invocation as an argv list
- makes `shell=False` explicit and preserves non-failing validator behavior with `check=False`
- documents why target_xml must not be interpolated into a shell command line

## Validation
- `python -m py_compile .claude/skills/subsystem-compile/scripts/subsystem-compile.py`
- `git diff --check`