### PR TITLE
В default.vrd надстройка для публикации http-сервисов расширений

### DIFF
--- a/docs/web-spec.md
+++ b/docs/web-spec.md
@@ -17,7 +17,7 @@
        ib="connection-string">
     <standardOdata enable="true"/>
     <ws pointEnableCommon="true"/>
-    <httpServices publishByDefault="true"/>
+    <httpServices publishByDefault="true" publishExtensionsByDefault="true"/>
 </point>
 ```
 


### PR DESCRIPTION
Включение в публикацию сразу http-сервисов расширений, удобно при подключении MCP поставляемых расширениями. ИИ помощник сам опубликует при их подключении к ИБ.