### PR TITLE
fix(role-validate): лишний позиционный аргумент затирал файл валидационным отчётом

### DIFF
--- a/.claude/skills/role-compile/SKILL.md
+++ b/.claude/skills/role-compile/SKILL.md
@@ -110,6 +110,6 @@ powershell.exe -NoProfile -File "${CLAUDE_SKILL_DIR}/scripts/role-compile.ps1" -
 ## Верификация
 
 ```
-/role-validate <RightsPath> [MetadataPath]  — проверка корректности XML, прав, RLS
-/role-info <RightsPath>                     — визуальная сводка структуры
+/role-validate <RightsPath>  — проверка XML, прав, RLS; метаданные (Roles/Имя.xml) и регистрация в Configuration.xml проверяются автоматически
+/role-info <RightsPath>      — визуальная сводка структуры
 ```

--- a/.claude/skills/role-validate/scripts/role-validate.ps1
+++ b/.claude/skills/role-validate/scripts/role-validate.ps1
@@ -1,7 +1,11 @@
 ﻿# role-validate v1.3 — Validate 1C role structure
 # Source: https://github.com/Nikolay-Shirokov/cc-1c-skills
+# PositionalBinding=$false: only -RightsPath is positional. This prevents a stray second
+# positional argument (e.g. a metadata path) from silently binding to -OutFile and
+# OVERWRITING that file with the validation report. -OutFile must be passed by name.
+[CmdletBinding(PositionalBinding=$false)]
 param(
-	[Parameter(Mandatory)]
+	[Parameter(Mandatory, Position=0)]
 	[Alias('Path')]
 	[string]$RightsPath,
 


### PR DESCRIPTION
## Суть

Вызов `role-validate.ps1` с двумя позиционными аргументами — естественная ошибка по текущей документации (`/role-validate <RightsPath> [MetadataPath]` в role-compile/SKILL.md): второй аргумент молча биндится в `-OutFile`, и скрипт **перезаписывает указанный файл текстом валидационного отчёта** (например, `Roles/Имя.xml`, если передать его вторым аргументом).

## Правка

- `[CmdletBinding(PositionalBinding=$false)]` + `Position=0` у `-RightsPath`: позиционным остаётся только путь к правам, `-OutFile` передаётся строго по имени. Лишний позиционный аргумент теперь падает ошибкой биндинга вместо молчаливой перезаписи файла.
- Справка в `role-compile/SKILL.md` приведена к факту: параметра `MetadataPath` в role-validate нет — метаданные (`Roles/Имя.xml`) и регистрация в Configuration.xml проверяются автоматически.

Python-порт не затронут: argparse принимает только именованные параметры, там позиционной ловушки нет.

## Проверки

`node tests/skills/runner.mjs cases/role-validate` — 7/7 passed (2 skipped) на PowerShell- и Python-рантаймах.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
