### PR TITLE
fix(role-compile): регистрация роли в Configuration.xml — текстовой правкой и в алфавитную позицию

### DIFF
--- a/.claude/skills/role-compile/scripts/role-compile.ps1
+++ b/.claude/skills/role-compile/scripts/role-compile.ps1
@@ -967,79 +967,60 @@ $configXmlPath = Join-Path $configDir "Configuration.xml"
 $regResult = $null
 
 if (Test-Path $configXmlPath) {
-	$configDoc = New-Object System.Xml.XmlDocument
-	$configDoc.PreserveWhitespace = $true
-	$configDoc.Load($configXmlPath)
+	# Текстовая правка вместо DOM: XmlDocument-round-trip переписывает ВЕСЬ файл
+	# (декларация, кавычки, пустые элементы), и пост-обработка гасит только известные
+	# классы шума — всё остальное утекает диффом. Точечная вставка одной строки
+	# оставляет прочие байты нетронутыми: EOL, BOM и стиль файла наследуются сами.
+	# Так же работает py-порт.
+	$cfgText = [System.IO.File]::ReadAllText($configXmlPath)
 
-	$nsMgr = New-Object System.Xml.XmlNamespaceManager($configDoc.NameTable)
-	$nsMgr.AddNamespace("md", "http://v8.1c.ru/8.3/MDClasses")
+	$roleRx = [regex]'(?m)^(?<indent>[ \t]*)<Role>(?<name>[^<]*)</Role>\r?\n'
+	$roleMatches = $roleRx.Matches($cfgText)
 
-	$childObjects = $configDoc.SelectSingleNode("//md:Configuration/md:ChildObjects", $nsMgr)
-	if ($childObjects) {
-		$existing = $childObjects.SelectNodes("md:Role", $nsMgr)
-		$alreadyExists = $false
-		foreach ($r in $existing) {
-			if ($r.InnerText -eq $roleName) {
-				$alreadyExists = $true
+	$alreadyExists = $false
+	foreach ($m in $roleMatches) {
+		if ($m.Groups['name'].Value -eq $roleName) { $alreadyExists = $true; break }
+	}
+
+	$eol = if ($cfgText.Contains("`r`n")) { "`r`n" } else { "`n" }
+
+	if ($alreadyExists) {
+		$regResult = "already"
+	} elseif ($roleMatches.Count -gt 0) {
+		# Позиция — алфавитная, а не «после последней»: выгрузка Конфигуратора держит
+		# роли в ChildObjects в порядке InvariantCulture (проверено на боевой
+		# конфигурации, 1056 ролей), и вставка в конец дала бы дифф на каждой
+		# следующей полной выгрузке.
+		$indent = $roleMatches[0].Groups['indent'].Value
+		$newLine = "$indent<Role>$roleName</Role>$eol"
+
+		$insertPos = -1
+		foreach ($m in $roleMatches) {
+			if ([string]::Compare($m.Groups['name'].Value, $roleName, [System.StringComparison]::InvariantCulture) -gt 0) {
+				$insertPos = $m.Index
 				break
 			}
 		}
-
-		if ($alreadyExists) {
-			$regResult = "already"
-		} else {
-			$roleElem = $configDoc.CreateElement("Role", "http://v8.1c.ru/8.3/MDClasses")
-			$roleElem.InnerText = $roleName
-
-			if ($existing.Count -gt 0) {
-				# Insert after last existing <Role>
-				$lastRole = $existing[$existing.Count - 1]
-				$newWs = $configDoc.CreateWhitespace("`n`t`t`t")
-				$childObjects.InsertAfter($newWs, $lastRole) | Out-Null
-				$childObjects.InsertAfter($roleElem, $newWs) | Out-Null
-			} else {
-				# No existing roles — insert before closing whitespace
-				$lastChild = $childObjects.LastChild
-				if ($lastChild.NodeType -eq [System.Xml.XmlNodeType]::Whitespace) {
-					$newWs = $configDoc.CreateWhitespace("`n`t`t`t")
-					$childObjects.InsertBefore($newWs, $lastChild) | Out-Null
-					$childObjects.InsertBefore($roleElem, $lastChild) | Out-Null
-				} else {
-					$childObjects.AppendChild($configDoc.CreateWhitespace("`n`t`t`t")) | Out-Null
-					$childObjects.AppendChild($roleElem) | Out-Null
-					$childObjects.AppendChild($configDoc.CreateWhitespace("`n`t`t")) | Out-Null
-				}
-			}
-
-			# Save
-			$cfgSettings = New-Object System.Xml.XmlWriterSettings
-			$cfgSettings.Encoding = New-Object System.Text.UTF8Encoding($true)
-			$cfgSettings.Indent = $false
-			$cfgSettings.NewLineHandling = [System.Xml.NewLineHandling]::None
-			# Через MemoryStream, а не прямо в файл: нужен шаг пост-обработки строки.
-			$memStream = New-Object System.IO.MemoryStream
-			$writer = [System.Xml.XmlWriter]::Create($memStream, $cfgSettings)
-			$configDoc.Save($writer)
-			$writer.Flush(); $writer.Close()
-
-			$cfgText = [System.Text.Encoding]::UTF8.GetString($memStream.ToArray())
-			$memStream.Close()
-			if ($cfgText.Length -gt 0 -and $cfgText[0] -eq [char]0xFEFF) { $cfgText = $cfgText.Substring(1) }
-			$cfgText = $cfgText.Replace('encoding="utf-8"', 'encoding="UTF-8"')
-			# Пустой элемент: XmlWriter отдаёт `<a />`, Конфигуратор пишет `<a/>`. Внутри
-			# CDATA/комментария ` />` может быть содержимым (там `>` не экранируется),
-			# поэтому они идут первыми ветками альтернации и возвращаются как есть.
-			$cfgText = [regex]::Replace($cfgText, '(?s)<!\[CDATA\[.*?\]\]>|<!--.*?-->|(?<=\S) />', { param($m) if ($m.Value -eq ' />') { '/>' } else { $m.Value } })
-			# Целевой перевод строки: стиль файла-назначения — правка наследует его (#44/#46/#47),
-			# новый файл получает канон выгрузки CRLF. Зеркало _detect_xml_style в py-порту.
-			$targetEol = if ((Test-Path -LiteralPath $configXmlPath) -and ([System.IO.File]::ReadAllText($configXmlPath) -notmatch "`r`n")) { "`n" } else { "`r`n" }
-			$cfgText = ($cfgText -replace "`r`n", "`n") -replace "`n", $targetEol
-			[System.IO.File]::WriteAllText($configXmlPath, $cfgText, (New-Object System.Text.UTF8Encoding($true)))
-
-			$regResult = "added"
+		if ($insertPos -lt 0) {
+			$last = $roleMatches[$roleMatches.Count - 1]
+			$insertPos = $last.Index + $last.Length
 		}
+
+		$cfgText = $cfgText.Substring(0, $insertPos) + $newLine + $cfgText.Substring($insertPos)
+		[System.IO.File]::WriteAllText($configXmlPath, $cfgText, (New-Object System.Text.UTF8Encoding($true)))
+		$regResult = "added"
 	} else {
-		$regResult = "no-childobj"
+		# Ролей ещё нет — вставка перед </ChildObjects>; отступ закрывающего тега +1 уровень.
+		$closeM = [regex]::Match($cfgText, '(?m)^(?<indent>[ \t]*)</ChildObjects>')
+		if ($closeM.Success) {
+			$indent = $closeM.Groups['indent'].Value
+			$newLine = "$indent`t<Role>$roleName</Role>$eol"
+			$cfgText = $cfgText.Substring(0, $closeM.Index) + $newLine + $cfgText.Substring($closeM.Index)
+			[System.IO.File]::WriteAllText($configXmlPath, $cfgText, (New-Object System.Text.UTF8Encoding($true)))
+			$regResult = "added"
+		} else {
+			$regResult = "no-childobj"
+		}
 	}
 } else {
 	$regResult = "no-config"

--- a/.claude/skills/role-compile/scripts/role-compile.py
+++ b/.claude/skills/role-compile/scripts/role-compile.py
@@ -1031,27 +1031,44 @@ def main():
         if f'<Role>{role_name}</Role>' in raw_text:
             reg_result = 'already'
         else:
-            # Find last <Role>...</Role> and insert after it
-            role_pattern = re.compile(r'(<Role>[^<]*</Role>)')
+            role_pattern = re.compile(r'(?m)^([ \t]*)<Role>([^<]*)</Role>(?:\r?\n)')
             matches = list(role_pattern.finditer(raw_text))
             new_role_tag = f'<Role>{role_name}</Role>'
 
             if matches:
-                # Insert after last existing <Role>
-                last_match = matches[-1]
-                insert_pos = last_match.end()
-                raw_text = raw_text[:insert_pos] + eol + f'\t\t\t{new_role_tag}' + raw_text[insert_pos:]
+                # Позиция — алфавитная, а не «после последней»: выгрузка Конфигуратора
+                # держит роли в ChildObjects в порядке InvariantCulture (проверено на
+                # боевой конфигурации, 1056 ролей), и вставка в конец дала бы дифф на
+                # каждой следующей полной выгрузке. casefold-ключ повторяет первичный
+                # (регистронезависимый) уровень этого порядка; отступ и EOL — из файла.
+                indent = matches[0].group(1)
+                new_line = f'{indent}{new_role_tag}{eol}'
+                new_key = role_name.casefold()
+                insert_pos = None
+                for m in matches:
+                    if m.group(2).casefold() > new_key:
+                        insert_pos = m.start()
+                        break
+                if insert_pos is None:
+                    insert_pos = matches[-1].end()
+                raw_text = raw_text[:insert_pos] + new_line + raw_text[insert_pos:]
+                write_utf8_bom(config_xml_path, raw_text)
+                reg_result = 'added'
             else:
                 # No existing roles — insert before </ChildObjects>
                 # Отступ вставки берём у закрывающего тега +1 уровень: подстановка
                 # по голому '</ChildObjects>' удваивала бы уже присутствующий отступ
-                # строки (получалось 5 табов вместо 3 — PS-порт через DOM даёт 3).
-                raw_text = re.sub(r'([ \t]*)</ChildObjects>',
-                                  lambda m: m.group(1) + '\t' + new_role_tag + eol + m.group(1) + '</ChildObjects>',
-                                  raw_text, count=1)
-
-            write_utf8_bom(config_xml_path, raw_text)
-            reg_result = 'added'
+                # строки (получалось 5 табов вместо 3 — PS-порт даёт 3).
+                raw_text, n_subs = re.subn(r'([ \t]*)</ChildObjects>',
+                                           lambda m: m.group(1) + '\t' + new_role_tag + eol + m.group(1) + '</ChildObjects>',
+                                           raw_text, count=1)
+                if n_subs:
+                    write_utf8_bom(config_xml_path, raw_text)
+                    reg_result = 'added'
+                else:
+                    # Раньше файл в этой ветке молча переписывался без вставки
+                    # и рапортовался как 'added'.
+                    reg_result = 'no-childobj'
     else:
         reg_result = 'no-config'
 


### PR DESCRIPTION
## Суть

Две грани одного дефекта регистрации роли в `ChildObjects` Configuration.xml.

**1. PS-порт переписывал весь файл.** Регистрация шла через XmlDocument-round-trip: пост-обработка гасит известные классы шума (encoding, `<a />`, EOL), но любые другие отличия DOM-сериализации утекают диффом — на боевом Configuration.xml это лишние правки в код-ревью. Py-порт при этом уже правил файл текстом — порты расходились по способу.

**2. Оба порта вставляли роль «после последней».** Выгрузка Конфигуратора держит роли в `ChildObjects` в алфавитном порядке: на боевой конфигурации (ЗУП КОРП, **1056 ролей**) порядок строго совпадает с сортировкой `InvariantCulture` — и не совпадает с `Ordinal` (в выгрузке `Docflow` < `DWH`, т.е. первичный уровень сравнения регистронезависимый). Вставка в конец списка гарантирует дифф при следующей полной выгрузке конфигурации.

## Правка

- PS-порт: точечная текстовая вставка одной строки вместо DOM-перезаписи — остальные байты, BOM и переводы строк не тронуты по построению; способ правки совпал с py.
- Оба порта: позиция вставки — перед первой ролью, которая старше по алфавиту (`InvariantCulture` в PS; в py — ключ `casefold`, повторяющий регистронезависимый первичный уровень этого порядка); в конец — только если новая роль действительно последняя.
- Сохранены все четыре исхода: `already` / `added` / `no-childobj` / `no-config`. Ветка «нет ни одной `<Role>`» вставляет перед `</ChildObjects>` с отступом закрывающего тега +1 уровень, как раньше.
- Попутно в py закрыта немая ветка: без единой `<Role>` и без `</ChildObjects>` файл переписывался без вставки и рапортовался как `added` — теперь честный `no-childobj`, как в PS.

## Проверки

- `node tests/skills/runner.mjs cases/role-compile` — 18/18 на PowerShell- и Python-рантаймах, **снапшоты не менялись** (на тестовых фикстурах результат байт-в-байт прежний).
- Гарды `check-all.mjs` — без новых падений.
- Смоук вставки в середину списка (роли Альфа/Омега + новая Бета): оба порта дают байт-идентичный результат, исходный файл отличается ровно одной вставленной строкой; на LF-фикстуре CR не появляется.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
