### PR TITLE
fix(tests,web-test): не отдавать rmSync/cpSync пути с не-ASCII символами (Node 24 win32)

### DIFF
--- a/.claude/skills/web-test/scripts/engine/core/fsutil.mjs
+++ b/.claude/skills/web-test/scripts/engine/core/fsutil.mjs
@@ -1,0 +1,29 @@
+// web-test core/fsutil v1.0 — надёжное удаление каталогов для движка.
+// Source: https://github.com/Nikolay-Shirokov/cc-1c-skills
+
+import { rmSync, unlinkSync, rmdirSync, readdirSync, existsSync } from 'fs';
+import { join } from 'path';
+
+// Node 24.x на Windows: fs.rmSync молча не делает ничего, если путь в аргументе
+// содержит не-ASCII символы — например кириллическое имя пользователя в %TEMP%
+// (nodejs/node#61067, проверено на v24.12.0). Ни исключения, ни удаления:
+// временные профили Chrome и каталоги TTS копятся с каждым запуском.
+// unlinkSync/rmdirSync не затронуты, поэтому такие пути вообще не отдаём rmSync,
+// а удаляем ручным обходом; после быстрого пути дополнительно проверяем результат.
+const nonAsciiPathUnsafe = (p) => process.platform === 'win32' && /[^\x00-\x7F]/.test(p);
+
+function rmTreeWalkSync(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) rmTreeWalkSync(p);
+    else unlinkSync(p);
+  }
+  rmdirSync(dir);
+}
+
+export function rmrfSync(dir) {
+  if (!nonAsciiPathUnsafe(dir)) rmSync(dir, { recursive: true, force: true });
+  if (!existsSync(dir)) return;
+  rmTreeWalkSync(dir);
+  if (existsSync(dir)) throw new Error(`Failed to remove directory: ${dir}`);
+}

--- a/.claude/skills/web-test/scripts/engine/core/session.mjs
+++ b/.claude/skills/web-test/scripts/engine/core/session.mjs
@@ -3,8 +3,9 @@
 
 import { chromium } from 'playwright';
 import { softDeadline } from './deadline.mjs';
-import { statSync, mkdirSync, readdirSync, rmSync } from 'fs';
+import { statSync, mkdirSync, readdirSync } from 'fs';
 import { join as pathJoin } from 'path';
+import { rmrfSync } from './fsutil.mjs';
 import { tmpdir } from 'os';
 import {
   browser, page, sessionPrefix, seanceId, recorder, highlightMode,
@@ -271,7 +272,7 @@ export async function disconnect() {
     setSeanceId(null);
     // Clean up persistent user data dir
     if (persistentUserDataDir) {
-      try { rmSync(persistentUserDataDir, { recursive: true, force: true }); } catch {}
+      try { rmrfSync(persistentUserDataDir); } catch {}
       setPersistentUserDataDir(null);
     }
   }
@@ -696,7 +697,7 @@ export async function abortContext(name, { logoutMs = 3000, closeMs = 5000, park
     setActiveContextName(null);
     setActiveMode(null);
     if (persistentUserDataDir) {
-      try { rmSync(persistentUserDataDir, { recursive: true, force: true }); } catch {}
+      try { rmrfSync(persistentUserDataDir); } catch {}
       setPersistentUserDataDir(null);
     }
     return out;
@@ -715,7 +716,7 @@ export async function abortContext(name, { logoutMs = 3000, closeMs = 5000, park
     setActiveContextName(null);
     setActiveMode(null);
     if (persistentUserDataDir) {
-      try { rmSync(persistentUserDataDir, { recursive: true, force: true }); } catch {}
+      try { rmrfSync(persistentUserDataDir); } catch {}
       setPersistentUserDataDir(null);
     }
     return out;

--- a/.claude/skills/web-test/scripts/engine/recording/narration.mjs
+++ b/.claude/skills/web-test/scripts/engine/recording/narration.mjs
@@ -2,8 +2,9 @@
 // Source: https://github.com/Nikolay-Shirokov/cc-1c-skills
 
 import { execFileSync } from 'child_process';
-import { existsSync as fsExistsSync, mkdirSync, readFileSync, rmSync, statSync } from 'fs';
+import { existsSync as fsExistsSync, mkdirSync, readFileSync, statSync } from 'fs';
 import { extname, join as pathJoin } from 'path';
+import { rmrfSync } from '../core/fsutil.mjs';
 import { tmpdir } from 'os';
 import {
   lastCaptions, lastRecordingDuration, resolveProjectPath,
@@ -191,6 +192,6 @@ export async function addNarration(videoPath, opts = {}) {
 
   } finally {
     // Cleanup temp directory
-    try { rmSync(tempDir, { recursive: true, force: true }); } catch {}
+    try { rmrfSync(tempDir); } catch {}
   }
 }

--- a/tests/skills/runner.mjs
+++ b/tests/skills/runner.mjs
@@ -3,7 +3,7 @@
 // Usage: node tests/skills/runner.mjs [filter] [--update-snapshots] [--runtime python] [--json report.json] [--concurrency N] [--with-validation]
 
 import { execFileSync, execFile } from 'child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync,
+import { existsSync, mkdirSync, mkdtempSync, rmSync, unlinkSync, rmdirSync, readFileSync, writeFileSync,
          readdirSync, statSync, cpSync, copyFileSync, chmodSync } from 'fs';
 import { createHash } from 'crypto';
 import { join, resolve, dirname, relative, basename, extname } from 'path';
@@ -16,6 +16,65 @@ const REPO_ROOT = resolve(ROOT, '../..');
 const SKILLS    = resolve(REPO_ROOT, '.claude/skills');
 const CASES     = resolve(ROOT, 'cases');
 const CACHE     = resolve(ROOT, '.cache');
+
+// ─── FS-хелперы ─────────────────────────────────────────────────────────────
+
+// Node 24.x на Windows fs.rmSync/fs.cpSync ломаются, когда путь в АРГУМЕНТЕ содержит
+// не-ASCII символы — кириллическое имя пользователя в %TEMP%, репозиторий в
+// кириллическом каталоге, кириллическое имя объекта 1С в deletePath (nodejs/node#61067,
+// проверено на v24.12.0). Проявления зависят от комбинации:
+//   - rmSync (файл или каталог) — МОЛЧА ничего не удаляет: воркспейсы копятся в %TEMP%,
+//     эталон не затирается перед --update-snapshots, deletePath не срабатывает;
+//   - cpSync с не-ASCII приёмником — МОЛЧА ничего не копирует: кейсы гоняются на
+//     пустом воркспейсе, а поверх существующего файла кидает «The operation
+//     completed successfully»;
+//   - cpSync с не-ASCII источником — НАТИВНО валит процесс (0xC0000409, try/catch
+//     не спасает).
+// unlinkSync/rmdirSync/copyFileSync/readdirSync не затронуты, поэтому такие пути
+// вообще не отдаём быстрому пути, а обрабатываем ручным обходом; после быстрого
+// пути дополнительно проверяем результат.
+const nonAsciiPathUnsafe = (p) => process.platform === 'win32' && /[^\x00-\x7F]/.test(p);
+
+function rmTreeWalkSync(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) rmTreeWalkSync(p);
+    else unlinkSync(p);
+  }
+  rmdirSync(dir);
+}
+
+function rmrfSync(dir, opts) {
+  if (!nonAsciiPathUnsafe(dir)) rmSync(dir, { recursive: true, force: true, ...opts });
+  if (!existsSync(dir)) return;
+  rmTreeWalkSync(dir);
+  if (existsSync(dir)) throw new Error(`Failed to remove directory: ${dir}`);
+}
+
+// Удалить файл ИЛИ каталог; отсутствие пути — не ошибка (семантика force).
+function rmPathSync(p) {
+  if (!existsSync(p)) return;
+  if (statSync(p).isDirectory()) rmrfSync(p);
+  else unlinkSync(p);
+}
+
+// Обойти источник и докопировать всё, что не доставил быстрый путь cpSync.
+function cpTreeRepairSync(src, dest) {
+  mkdirSync(dest, { recursive: true });
+  for (const entry of readdirSync(src, { withFileTypes: true })) {
+    const s = join(src, entry.name);
+    const d = join(dest, entry.name);
+    if (entry.isDirectory()) cpTreeRepairSync(s, d);
+    else if (!existsSync(d)) copyFileSync(s, d);
+  }
+}
+
+function cpTreeSync(src, dest) {
+  if (!nonAsciiPathUnsafe(src) && !nonAsciiPathUnsafe(dest)) {
+    try { cpSync(src, dest, { recursive: true }); } catch { /* доберём обходом */ }
+  }
+  cpTreeRepairSync(src, dest);
+}
 
 // ─── CLI args ───────────────────────────────────────────────────────────────
 
@@ -158,7 +217,7 @@ function ensureSetup(setupName, runtime, skillCasesDir) {
     const want = fixtureStamp(EMPTY_CONFIGS[setupName]);
     if (existsSync(cached)) {
       if (existsSync(stamp) && readFileSync(stamp, 'utf8') === want) return cached;
-      rmSync(cached, { recursive: true, force: true });
+      rmrfSync(cached);
     }
 
     mkdirSync(cached, { recursive: true });
@@ -167,7 +226,9 @@ function ensureSetup(setupName, runtime, skillCasesDir) {
       execSkillRaw(runtime, script, ['-Name', 'TestConfig', '-OutputDir', cached, ...EMPTY_CONFIGS[setupName]]);
       writeFileSync(stamp, want, 'utf8');
     } catch (e) {
-      rmSync(cached, { recursive: true, force: true });
+      // Недоснятая фикстура, оставшаяся на диске, молча ушла бы в следующий прогон
+      try { rmrfSync(cached); }
+      catch (cleanupError) { console.warn(`Warning: failed to remove partial fixture ${cached}: ${cleanupError.message}`); }
       throw new Error(`Failed to create ${setupName} fixture: ${e.message}`);
     }
     return cached;
@@ -249,7 +310,7 @@ function createWorkspace(fixturePath, readOnly) {
   }
   const tmp = mkdtempSync(join(tmpdir(), 'skill-test-'));
   if (fixturePath) {
-    cpSync(fixturePath, tmp, { recursive: true });
+    cpTreeSync(fixturePath, tmp);
   }
   return { path: tmp, readOnly: false };
 }
@@ -260,7 +321,7 @@ function cleanupWorkspace(ws) {
   // process exits — rmSync then throws EBUSY. Retry a few times, then swallow:
   // a leaked tmp dir is preferable to crashing the entire runner.
   try {
-    rmSync(ws.path, { recursive: true, force: true, maxRetries: 10, retryDelay: 200 });
+    rmrfSync(ws.path, { maxRetries: 10, retryDelay: 200 });
   } catch (e) {
     console.warn(`Warning: failed to clean workspace ${ws.path}: ${e.message}`);
   }
@@ -636,8 +697,8 @@ function updateSnapshot(workDir, snapshotDir, snapshotConfig, caseData) {
   // дорисовал бы эталон и сам породил противоречие с opt-out.
   if (caseData?.noSnapshot) return;
 
-  // Remove old snapshot
-  if (existsSync(snapshotDir)) rmSync(snapshotDir, { recursive: true, force: true });
+  // Remove old snapshot (молчаливый отказ здесь оставил бы стейл в эталоне)
+  if (existsSync(snapshotDir)) rmrfSync(snapshotDir);
 
   // Determine which files to snapshot — all files in workDir that were created by the skill
   // For "workDir" root mode, we need to figure out what files the skill added.
@@ -770,7 +831,7 @@ async function runCaseAsync(testCase, opts) {
         // deletePath step — убрать файл или каталог из workDir: так выражается состояние,
         // которое навыки сами не создают (например, пометка свойства без файла модуля).
         if (step.deletePath) {
-          rmSync(join(workDir, step.deletePath), { recursive: true, force: true });
+          rmPathSync(join(workDir, step.deletePath));
           continue;
         }
         const preScript = resolveScript(step.script, opts.runtime);
@@ -794,7 +855,7 @@ async function runCaseAsync(testCase, opts) {
         } catch (e) {
           throw new Error(`preRun step "${step.script}" failed: ${e.stderr || e.message}`);
         }
-        if (preInputFile && existsSync(preInputFile)) rmSync(preInputFile);
+        if (preInputFile && existsSync(preInputFile)) unlinkSync(preInputFile);
       }
     }
 
@@ -816,7 +877,7 @@ async function runCaseAsync(testCase, opts) {
       stderr = e.stderr || '';
     }
 
-    if (inputFile && existsSync(inputFile)) rmSync(inputFile);
+    if (inputFile && existsSync(inputFile)) unlinkSync(inputFile);
 
     // Assertions
     const errors = [];
@@ -1016,7 +1077,7 @@ function runCase(testCase, opts) {
         } catch (e) {
           throw new Error(`preRun step "${step.script}" failed: ${e.stderr || e.message}`);
         }
-        if (preInputFile && existsSync(preInputFile)) rmSync(preInputFile);
+        if (preInputFile && existsSync(preInputFile)) unlinkSync(preInputFile);
       }
     }
 
@@ -1040,7 +1101,7 @@ function runCase(testCase, opts) {
     }
 
     // Remove temp input file from workDir before snapshot comparison
-    if (inputFile && existsSync(inputFile)) rmSync(inputFile);
+    if (inputFile && existsSync(inputFile)) unlinkSync(inputFile);
 
     // 4. Assertions
     const errors = [];
@@ -1484,7 +1545,7 @@ async function runIntegrationOnce(test, opts, engine, labelEngine) {
         break; // stop on first failure
       }
 
-      if (inputFile && existsSync(inputFile)) rmSync(inputFile);
+      if (inputFile && existsSync(inputFile)) unlinkSync(inputFile);
 
       // Post-step validation
       if (opts.withValidation && step.validate) {
@@ -1510,8 +1571,8 @@ async function runIntegrationOnce(test, opts, engine, labelEngine) {
     // Cache result if configured
     if (test.cache && stepResults.every(s => s.passed)) {
       const cachePath = join(CACHE, test.cache);
-      if (existsSync(cachePath)) rmSync(cachePath, { recursive: true, force: true });
-      cpSync(workDir, cachePath, { recursive: true });
+      if (existsSync(cachePath)) rmrfSync(cachePath);
+      cpTreeSync(workDir, cachePath);
     }
 
     const allPassed = stepResults.every(s => s.passed);

--- a/tests/skills/verify-snapshots.mjs
+++ b/tests/skills/verify-snapshots.mjs
@@ -12,7 +12,7 @@
 // типовой конфигурации (~3 мин на кейс, ноль информации). Такие гонять через --case.
 
 import { execFileSync } from 'child_process';
-import { existsSync, mkdirSync, mkdtempSync, rmSync, readFileSync, writeFileSync,
+import { existsSync, mkdirSync, mkdtempSync, rmSync, unlinkSync, rmdirSync, readFileSync, writeFileSync,
          readdirSync, statSync, cpSync, copyFileSync, chmodSync } from 'fs';
 import { join, resolve, dirname, basename } from 'path';
 import { tmpdir } from 'os';
@@ -24,6 +24,53 @@ const REPO_ROOT = resolve(ROOT, '../..');
 const SKILLS    = resolve(REPO_ROOT, '.claude/skills');
 const CASES     = resolve(ROOT, 'cases');
 const REPORT_DIR = resolve(REPO_ROOT, 'debug/snapshot-verify');
+
+// ─── FS-хелперы ─────────────────────────────────────────────────────────────
+
+// Node 24.x на Windows fs.rmSync/fs.cpSync ломаются, когда путь в АРГУМЕНТЕ содержит
+// не-ASCII символы — например кириллическое имя пользователя в %TEMP%
+// (nodejs/node#61067, проверено на v24.12.0). Проявления зависят от комбинации:
+// rmSync молча ничего не удаляет; cpSync с не-ASCII приёмником молча ничего не
+// копирует (а поверх существующего файла кидает «The operation completed
+// successfully»); cpSync с не-ASCII источником НАТИВНО валит процесс (0xC0000409).
+// unlinkSync/rmdirSync/copyFileSync/readdirSync не затронуты, поэтому такие пути
+// вообще не отдаём быстрому пути, а обрабатываем ручным обходом; после быстрого
+// пути дополнительно проверяем результат.
+const nonAsciiPathUnsafe = (p) => process.platform === 'win32' && /[^\x00-\x7F]/.test(p);
+
+function rmTreeWalkSync(dir) {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const p = join(dir, entry.name);
+    if (entry.isDirectory()) rmTreeWalkSync(p);
+    else unlinkSync(p);
+  }
+  rmdirSync(dir);
+}
+
+function rmrfSync(dir) {
+  if (!nonAsciiPathUnsafe(dir)) rmSync(dir, { recursive: true, force: true });
+  if (!existsSync(dir)) return;
+  rmTreeWalkSync(dir);
+  if (existsSync(dir)) throw new Error(`Failed to remove directory: ${dir}`);
+}
+
+// Обойти источник и докопировать всё, что не доставил быстрый путь cpSync.
+function cpTreeRepairSync(src, dest) {
+  mkdirSync(dest, { recursive: true });
+  for (const entry of readdirSync(src, { withFileTypes: true })) {
+    const s = join(src, entry.name);
+    const d = join(dest, entry.name);
+    if (entry.isDirectory()) cpTreeRepairSync(s, d);
+    else if (!existsSync(d)) copyFileSync(s, d);
+  }
+}
+
+function cpTreeSync(src, dest) {
+  if (!nonAsciiPathUnsafe(src) && !nonAsciiPathUnsafe(dest)) {
+    try { cpSync(src, dest, { recursive: true }); } catch { /* доберём обходом */ }
+  }
+  cpTreeRepairSync(src, dest);
+}
 
 // ─── CLI args ───────────────────────────────────────────────────────────────
 
@@ -658,7 +705,7 @@ function runPreSteps(preRun, workDir, runtime, log) {
       log(`preRun: ${stepName}`, false, e.stderr || e.message);
       throw new Error(`preRun "${step.script}" failed: ${(e.stderr || e.message).substring(0, 500)}`);
     }
-    if (preInputFile && existsSync(preInputFile)) rmSync(preInputFile);
+    if (preInputFile && existsSync(preInputFile)) unlinkSync(preInputFile);
   }
 }
 
@@ -818,7 +865,7 @@ async function verifyCase(skillName, caseName, skillConfig, caseData, opts) {
         result.errors.push(`Fixture not found: ${fixturePath}`);
         return result;
       }
-      cpSync(fixturePath, workDir, { recursive: true });
+      cpTreeSync(fixturePath, workDir);
       log(`fixture: ${fixtureName}`, true);
     } else if (typeof caseData.setup === 'string' && caseData.setup.startsWith('external:')) {
       const extPath = resolve(REPO_ROOT, caseData.setup.slice('external:'.length));
@@ -831,7 +878,7 @@ async function verifyCase(skillName, caseName, skillConfig, caseData, opts) {
         result.skipReason = `внешняя выгрузка недоступна на этой машине: ${extPath}`;
         return result;
       }
-      cpSync(extPath, workDir, { recursive: true });
+      cpTreeSync(extPath, workDir);
       log(`external: ${extPath}`, true);
       configDir = workDir;
     }
@@ -985,7 +1032,7 @@ async function verifyCase(skillName, caseName, skillConfig, caseData, opts) {
       result.errors.push(`${skillName} failed: ${detail.substring(0, 500)}`);
       return result;
     }
-    if (inputFile && existsSync(inputFile)) rmSync(inputFile);
+    if (inputFile && existsSync(inputFile)) unlinkSync(inputFile);
 
     // Режим совместимости конфигурации выше платформы — она такую не загрузит. Это свойство
     // стенда, а не дефект кейса, поэтому пропускаем с причиной: иначе на машине без нужной
@@ -1030,7 +1077,7 @@ async function verifyCase(skillName, caseName, skillConfig, caseData, opts) {
         return result;
       }
       const dcsTpl = join(erfDir, 'TestReport', 'Templates', 'ОсновнаяСхемаКомпоновкиДанных', 'Ext', 'Template.xml');
-      cpSync(tplPath, dcsTpl, { force: true });
+      copyFileSync(tplPath, dcsTpl);
       try {
         execSkill(opts.runtime, 'epf-build/scripts/epf-build', [
           '-V8Path', opts.v8ctx.v8path,
@@ -1082,7 +1129,7 @@ async function verifyCase(skillName, caseName, skillConfig, caseData, opts) {
         return result;
       }
       const tplDest = join(epfDir, 'TestProc', 'Templates', 'Макет', 'Ext', 'Template.xml');
-      cpSync(tplPath, tplDest, { force: true });
+      copyFileSync(tplPath, tplDest);
       try {
         execSkill(opts.runtime, 'epf-build/scripts/epf-build', [
           '-V8Path', opts.v8ctx.v8path,
@@ -1409,8 +1456,8 @@ async function verifyCase(skillName, caseName, skillConfig, caseData, opts) {
     result.errors.push(`Unexpected error: ${e.message}`);
   } finally {
     if (!opts.keep) {
-      try { rmSync(workDir, { recursive: true, force: true }); } catch {}
-      result.workDir = '(cleaned)';
+      // При неудаче оставляем в result реальный путь — остаток каталога виден в отчёте
+      try { rmrfSync(workDir); result.workDir = '(cleaned)'; } catch {}
     }
   }
 


### PR DESCRIPTION
## Суть

На Node 24.x под Windows `fs.rmSync` и `fs.cpSync` ломаются, когда путь в аргументе содержит не-ASCII символы (nodejs/node#61067, воспроизведено на v24.12.0). Для аудитории проекта это боевой сценарий: кириллическое имя пользователя Windows даёт кириллический `%TEMP%`, где раннер создаёт все воркспейсы, плюс кириллические имена объектов 1С в путях внутри кейсов.

Проявления зависят от комбинации (каждое снято минимальным репро вне раннера):

| Вызов | Не-ASCII где | Поведение |
|---|---|---|
| `rmSync` (файл или каталог, любые флаги) | в аргументе | молча ничего не удаляет |
| `cpSync` recursive | в приёмнике | молча копирует ничего |
| `cpSync` одиночного файла поверх существующего | в приёмнике | бросает «The operation completed successfully», файл не заменён |
| `cpSync` recursive | в источнике | нативно валит процесс (0xC0000409), try/catch не спасает |
| `unlinkSync` / `rmdirSync` / `copyFileSync` / `readdirSync` | где угодно | работают корректно |

Важно: рекурсивная обработка ASCII-каталога с кириллическими файлами ВНУТРИ работает — триггер именно содержимое аргумента.

## Что это ломало в тестах

1. `cases/cfe-validate/module-state-flag-without-file` красный на текущем main даже при ASCII `%TEMP%`: шаг `deletePath` не удаляет `cfe/CommonModules/ОбщийМодуль1/Ext/Module.bsl` (кириллица в аргументе), `Module.bsl` выживает, ожидаемое предупреждение не рождается.
2. Под кириллическим `%TEMP%` `integration/build-config` нативно убивает весь прогон — кэширование base-config делает `cpSync` из кириллического воркспейса.
3. Под кириллическим `%TEMP%` фикстуры не доезжают до воркспейсов — массовые ложные «Snapshot: file missing» (7/12 в одном только `cases/meta-info`), и каждый воркспейс утекает (8 каталогов за 12 кейсов).
4. `--update-snapshots` при кириллическом пути к репозиторию молча не затирает старый эталон — стейл в снэпшотах.
5. web-test: временный профиль Chrome и каталог TTS-нарезки копятся с каждым запуском.

## Что сделано

- В `runner.mjs` и `verify-snapshots.mjs` добавлены хелперы `rmrfSync` / `cpTreeSync` (+ `rmPathSync` для `deletePath`): ASCII-пути идут прежним быстрым путём с проверкой результата после, а пути с не-ASCII вообще не передаются `rmSync`/`cpSync` и обрабатываются ручным обходом на `unlinkSync`/`rmdirSync`/`copyFileSync`.
- Удаления одиночных файлов (`__input.json`, `__pre_input.json`) переведены на `unlinkSync`.
- Для движка web-test хелпер вынесен в `engine/core/fsutil.mjs`, подключён в `core/session.mjs` и `recording/narration.mjs`.
- Копирование макетов `cpSync(tplPath, ..., { force: true })` заменено на `copyFileSync` — тот же смысл, но не спотыкается о кириллический сегмент `Templates/Макет/...`.
- Поведение при настоящих ошибках сохранено: очистка воркспейса по-прежнему warn+swallow (EBUSY-ретраи прокинуты в быстрый путь), снос эталона и кэша — громкий.

## Проверка

Node v24.12.0, Windows:

- Полный прогон с обычным ASCII `%TEMP%`: интеграция 10/10; кейсы 800 passed / 46 skipped / 0 failed; exit 0.
- Полный прогон с `%TEMP%`, содержащим кириллический сегмент: тот же результат и ноль утёкших воркспейсов. До фикса этот же прогон нативно падал на build-config, а без интеграции — массово красил снэпшот-сравнения и терял воркспейсы.
- `module-state-flag-without-file` позеленел: `deletePath` реально удаляет файл модуля.

Те же паттерны остались во вспомогательных скриптах (`tests/skills/build-webtest-db.mjs`, `check-positional-binding.mjs`, `check-uuid-invariant.mjs`, `tests/web-test/_hooks.mjs`, `hooks/test/run.mjs`) — там пути почти всегда ASCII, стреляет только кириллический `%TEMP%`/путь к репо. Могу раскатать тем же хелпером отдельным PR, если это нужно.

Чинится и апгрейдом Node на версию с фиксом libuv, но гард дешёвый, для ASCII-путей ничего не меняет и держит тесты честными на любой версии Node.
